### PR TITLE
Cleaned-up notebook for use of PIL

### DIFF
--- a/MNIST_GenData.ipynb
+++ b/MNIST_GenData.ipynb
@@ -1,103 +1,30 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 29,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: mnist in c:\\users\\chanchala\\appdata\\local\\programs\\python\\python36\\lib\\site-packages (0.2.2)\n",
-      "Requirement already satisfied: numpy in c:\\users\\chanchala\\appdata\\local\\programs\\python\\python36\\lib\\site-packages (from mnist) (1.16.4)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "You are using pip version 19.0.3, however version 19.1.1 is available.\n",
-      "You should consider upgrading via the 'python -m pip install --upgrade pip' command.\n"
-     ]
-    }
-   ],
    "source": [
-    "!pip install --proxy http://proxy-us.intel.com:911 mnist"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: onnxruntime in c:\\users\\chanchala\\appdata\\local\\programs\\python\\python36\\lib\\site-packages (0.3.0)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "You are using pip version 19.0.3, however version 19.1.1 is available.\n",
-      "You should consider upgrading via the 'python -m pip install --upgrade pip' command.\n"
-     ]
-    }
-   ],
-   "source": [
-    "!pip install --proxy http://proxy-us.intel.com:911 onnxruntime"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: onnx in c:\\users\\chanchala\\appdata\\local\\programs\\python\\python36\\lib\\site-packages (1.5.0)\n",
-      "Requirement already satisfied: protobuf in c:\\users\\chanchala\\appdata\\local\\programs\\python\\python36\\lib\\site-packages (from onnx) (3.8.0)\n",
-      "Requirement already satisfied: typing-extensions>=3.6.2.1 in c:\\users\\chanchala\\appdata\\local\\programs\\python\\python36\\lib\\site-packages (from onnx) (3.7.4)\n",
-      "Requirement already satisfied: numpy in c:\\users\\chanchala\\appdata\\local\\programs\\python\\python36\\lib\\site-packages (from onnx) (1.16.4)\n",
-      "Requirement already satisfied: six in c:\\users\\chanchala\\appdata\\local\\programs\\python\\python36\\lib\\site-packages (from onnx) (1.12.0)\n",
-      "Requirement already satisfied: typing>=3.6.4 in c:\\users\\chanchala\\appdata\\local\\programs\\python\\python36\\lib\\site-packages (from onnx) (3.7.4)\n",
-      "Requirement already satisfied: setuptools in c:\\users\\chanchala\\appdata\\local\\programs\\python\\python36\\lib\\site-packages (from protobuf->onnx) (40.6.2)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "You are using pip version 19.0.3, however version 19.1.1 is available.\n",
-      "You should consider upgrading via the 'python -m pip install --upgrade pip' command.\n"
-     ]
-    }
-   ],
-   "source": [
-    "!pip install --proxy http://proxy-us.intel.com:911 onnx"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import mnist"
+    "# Install requirements\n",
+    "\n",
+    "Eventually these requirements should make it into a `requirements.txt` or `env.yaml`, but for the moment installing as part of the notebook."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: mnist in /opt/conda/lib/python3.7/site-packages (0.2.2)\r\n",
+      "Requirement already satisfied: numpy in /opt/conda/lib/python3.7/site-packages (from mnist) (1.15.4)\r\n"
+     ]
+    }
+   ],
    "source": [
-    "mnist.temporary_dir = lambda : '.\\\\data'"
+    "!pip install mnist"
    ]
   },
   {
@@ -106,46 +33,74 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "['IdxDecodeError',\n",
-       " 'array',\n",
-       " 'datasets_url',\n",
-       " 'download_and_parse_mnist_file',\n",
-       " 'download_file',\n",
-       " 'functools',\n",
-       " 'gzip',\n",
-       " 'numpy',\n",
-       " 'operator',\n",
-       " 'os',\n",
-       " 'parse_idx',\n",
-       " 'struct',\n",
-       " 'tempfile',\n",
-       " 'temporary_dir',\n",
-       " 'test_images',\n",
-       " 'test_labels',\n",
-       " 'train_images',\n",
-       " 'train_labels',\n",
-       " 'urljoin',\n",
-       " 'urlretrieve']"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting onnxruntime\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/5f/69/12e7048508193cb9cebca27202c247cc847e75ab7894a21513debdb2d935/onnxruntime-0.4.0-cp37-cp37m-manylinux1_x86_64.whl (3.1MB)\n",
+      "\u001b[K     |████████████████████████████████| 3.1MB 886kB/s eta 0:00:01\n",
+      "\u001b[?25hInstalling collected packages: onnxruntime\n",
+      "Successfully installed onnxruntime-0.4.0\n"
+     ]
     }
    ],
    "source": [
-    "[d for d in dir(mnist) if not d.startswith('_')]"
+    "!pip install onnxruntime"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting onnx\n",
+      "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/c4/f7/6bb9782e7020a21154182b5de2169ed9393cc065359515aa6fccecdad618/onnx-1.5.0-cp37-cp37m-manylinux1_x86_64.whl (7.0MB)\n",
+      "\u001b[K     |████████████████████████████████| 7.1MB 693kB/s eta 0:00:01\n",
+      "\u001b[?25hCollecting typing>=3.6.4 (from onnx)\n",
+      "  Downloading https://files.pythonhosted.org/packages/28/b8/a1d6b7cf322f91305bcb5e7d8f6c3028954d1e3e716cddc1cdce2ac63247/typing-3.7.4-py3-none-any.whl\n",
+      "Requirement already satisfied: numpy in /opt/conda/lib/python3.7/site-packages (from onnx) (1.15.4)\n",
+      "Collecting typing-extensions>=3.6.2.1 (from onnx)\n",
+      "  Downloading https://files.pythonhosted.org/packages/27/aa/bd1442cfb0224da1b671ab334d3b0a4302e4161ea916e28904ff9618d471/typing_extensions-3.7.4-py3-none-any.whl\n",
+      "Requirement already satisfied: protobuf in /opt/conda/lib/python3.7/site-packages (from onnx) (3.7.1)\n",
+      "Requirement already satisfied: six in /opt/conda/lib/python3.7/site-packages (from onnx) (1.12.0)\n",
+      "Requirement already satisfied: setuptools in /opt/conda/lib/python3.7/site-packages (from protobuf->onnx) (41.0.1)\n",
+      "Installing collected packages: typing, typing-extensions, onnx\n",
+      "Successfully installed onnx-1.5.0 typing-3.7.4 typing-extensions-3.7.4\n"
+     ]
+    }
+   ],
    "source": [
-    "test_images = mnist.test_images().tolist()"
+    "!pip install onnx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: pillow in /opt/conda/lib/python3.7/site-packages (6.0.0)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install pillow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load MNIST dataset\n",
+    "\n",
+    "Here the \"test\" subset of the handwritten-digit recognition dataset, but to use the training (bigger) subset, the method only requires using `train_images` rather than `test_images` below."
    ]
   },
   {
@@ -154,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert(len(test_images) == 10000)"
+    "import mnist"
    ]
   },
   {
@@ -163,27 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os, sys"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['mnist', 't10k-images-idx3-ubyte.gz', 't10k-labels-idx1-ubyte.gz']"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "os.listdir('.\\\\data')"
+    "mnist.temporary_dir = lambda : '/data/mnist-data'"
    ]
   },
   {
@@ -192,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib inline"
+    "test_images = mnist.test_images().tolist()"
    ]
   },
   {
@@ -201,35 +136,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np"
+    "assert(len(test_images) == 10000)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "list"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "type(test_images[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Looks like each image is parsed into a list of lists:"
+    "import os, sys"
    ]
   },
   {
@@ -240,10 +156,78 @@
     {
      "data": {
       "text/plain": [
-       "list"
+       "['t10k-images-idx3-ubyte.gz']"
       ]
      },
      "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "os.listdir('/data/mnist-data')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from PIL import Image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `mnist` module parses the original dataset, each image encoded as a list with 28 elements, each a list of 28 integers in the range 0-255:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(test_images[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "list"
+      ]
+     },
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -254,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -263,7 +247,7 @@
        "28"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -274,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -283,7 +267,7 @@
        "28"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -293,12 +277,221 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This encoding can be read as `numpy` arrays as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_mat = np.array(test_images[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(28, 28)"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_mat.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that by default the array is read as `int64`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dtype('int64')"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_mat.dtype"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use this form to verify that the images are being adequately read:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7f6641995588>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP8AAAD8CAYAAAC4nHJkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAADVlJREFUeJzt3W+IXfWdx/HPZ2OjwRZ1zGhCGp1YpI6KTcoQg8riUgx2LcQ8iHSUkmJp+qDKFvtAzZNGQQzLtjUPlkK6iYna2hbamAiyNsiKKWhwlKGapm40zjbZxGRCirEiVDPffTAn3Wmce+7N/Xfu5Pt+Qbj3nu/58+WSz5x77+/e83NECEA+/1B1AwCqQfiBpAg/kBThB5Ii/EBShB9IivADSRF+ICnCDyR1TjcPNnfu3BgYGOjmIYFUxsbGdOzYMTeybkvht32rpA2SZkn6j4hYX7b+wMCARkZGWjkkgBJDQ0MNr9v0y37bsyT9u6SvSrpa0rDtq5vdH4DuauU9/1JJb0fE/oj4q6RfSFrRnrYAdFor4V8g6cCUxweLZX/H9hrbI7ZHxsfHWzgcgHZqJfzTfajwqd8HR8TGiBiKiKH+/v4WDgegnVoJ/0FJC6c8/rykQ621A6BbWgn/q5KutL3I9mxJX5e0oz1tAei0pof6IuIT2/dIel6TQ32bI2JP2zoD0FEtjfNHxHOSnmtTLwC6iK/3AkkRfiApwg8kRfiBpAg/kBThB5Ii/EBShB9IivADSRF+ICnCDyRF+IGkCD+QFOEHkiL8QFKEH0iK8ANJEX4gKcIPJEX4gaQIP5AU4QeSIvxAUoQfSIrwA0kRfiApwg8kRfiBpAg/kFRLs/TaHpP0gaSTkj6JiKF2NAWg81oKf+GfIuJYG/YDoIt42Q8k1Wr4Q9Jvbb9me007GgLQHa2+7L8xIg7ZvkTSTtt/jIiXpq5Q/FFYI0mXXXZZi4cD0C4tnfkj4lBxe1TSNklLp1lnY0QMRcRQf39/K4cD0EZNh9/2+bY/d+q+pOWS3mxXYwA6q5WX/ZdK2mb71H5+HhH/2ZauAHRc0+GPiP2SvtTGXgB0EUN9QFKEH0iK8ANJEX4gKcIPJEX4gaTa8au+FF555ZWatQ0bNpRuu2DBgtL6nDlzSuurV68urff19TVVQ26c+YGkCD+QFOEHkiL8QFKEH0iK8ANJEX4gKcb5G1Q21r5v376OHvuRRx4prV9wwQU1a8uWLWt3OzPGwMBAzdqDDz5Yum2GS85x5geSIvxAUoQfSIrwA0kRfiApwg8kRfiBpBjnb9AzzzxTszY6Olq67TXXXFNa37NnT2l99+7dpfXt27fXrD3//POl2y5atKi0/u6775bWW3HOOeX//ebPn19aP3DgQNPHLvsOgCTdf//9Te97puDMDyRF+IGkCD+QFOEHkiL8QFKEH0iK8ANJ1R3nt71Z0tckHY2Ia4tlfZJ+KWlA0pikOyLiz51rs3qDg4NN1Rpx3XXXldaHh4dL6+vXr69ZGxsbK9223jj//v37S+utmD17dmm93jh/vd7Hx8dr1q666qrSbTNo5My/RdKtpy17QNILEXGlpBeKxwBmkLrhj4iXJB0/bfEKSVuL+1sl3d7mvgB0WLPv+S+NiMOSVNxe0r6WAHRDxz/ws73G9ojtkbL3YAC6q9nwH7E9X5KK26O1VoyIjRExFBFD/f39TR4OQLs1G/4dkk5dzna1pNo/KwPQk+qG3/bTkl6W9EXbB21/S9J6SbfY3ifpluIxgBmk7jh/RNQaZP5Km3tBk84777yatVbHs1v9DkMr6l3H4NixY6X166+/vmZt+fLlTfV0NuEbfkBShB9IivADSRF+ICnCDyRF+IGkuHQ3KvPhhx+W1leuXFlan5iYKK0/9thjNWtz5swp3TYDzvxAUoQfSIrwA0kRfiApwg8kRfiBpAg/kBTj/KjMli1bSuvvvfdeaf3iiy8urV9++eVn2lIqnPmBpAg/kBThB5Ii/EBShB9IivADSRF+ICnG+dFR77zzTs3afffd19K+X3755dL6vHnzWtr/2Y4zP5AU4QeSIvxAUoQfSIrwA0kRfiApwg8kVXec3/ZmSV+TdDQiri2WrZP0bUnjxWprI+K5TjWJmevZZ5+tWfv4449Lt121alVp/YorrmiqJ0xq5My/RdKt0yz/cUQsLv4RfGCGqRv+iHhJ0vEu9AKgi1p5z3+P7d/b3mz7orZ1BKArmg3/TyR9QdJiSYcl/bDWirbX2B6xPTI+Pl5rNQBd1lT4I+JIRJyMiAlJP5W0tGTdjRExFBFD/f39zfYJoM2aCr/t+VMerpT0ZnvaAdAtjQz1PS3pZklzbR+U9ANJN9teLCkkjUn6Tgd7BNABdcMfEcPTLN7UgV4wA9Ubq9+2bVvN2rnnnlu67aOPPlpanzVrVmkd5fiGH5AU4QeSIvxAUoQfSIrwA0kRfiApLt2NlmzaVD7qu2vXrpq1O++8s3RbfrLbWZz5gaQIP5AU4QeSIvxAUoQfSIrwA0kRfiApxvlRanR0tLR+7733ltYvvPDCmrWHH364qZ7QHpz5gaQIP5AU4QeSIvxAUoQfSIrwA0kRfiApxvmT++ijj0rrw8PTXbn9/508ebK0ftddd9Ws8Xv9anHmB5Ii/EBShB9IivADSRF+ICnCDyRF+IGk6o7z214o6QlJ8yRNSNoYERts90n6paQBSWOS7oiIP3euVTRjYmKitH7bbbeV1t96663S+uDgYGn9oYceKq2jOo2c+T+R9P2IGJS0TNJ3bV8t6QFJL0TElZJeKB4DmCHqhj8iDkfE68X9DyTtlbRA0gpJW4vVtkq6vVNNAmi/M3rPb3tA0hJJuyVdGhGHpck/EJIuaXdzADqn4fDb/qykX0v6XkScOIPt1tgesT0yPj7eTI8AOqCh8Nv+jCaD/7OI+E2x+Ijt+UV9vqSj020bERsjYigihvr7+9vRM4A2qBt+25a0SdLeiPjRlNIOSauL+6slbW9/ewA6pZGf9N4o6RuS3rB96jrOayWtl/Qr29+S9CdJqzrTIlpx/Pjx0vqLL77Y0v6ffPLJ0npfX19L+0fn1A1/RPxOkmuUv9LedgB0C9/wA5Ii/EBShB9IivADSRF+ICnCDyTFpbvPAu+//37N2rJly1ra91NPPVVaX7JkSUv7R3U48wNJEX4gKcIPJEX4gaQIP5AU4QeSIvxAUozznwUef/zxmrX9+/e3tO+bbrqptD55rRfMRJz5gaQIP5AU4QeSIvxAUoQfSIrwA0kRfiApxvlngH379pXW161b151GcFbhzA8kRfiBpAg/kBThB5Ii/EBShB9IivADSdUd57e9UNITkuZJmpC0MSI22F4n6duSxotV10bEc51qNLNdu3aV1k+cONH0vgcHB0vrc+bMaXrf6G2NfMnnE0nfj4jXbX9O0mu2dxa1H0fEv3WuPQCdUjf8EXFY0uHi/ge290pa0OnGAHTWGb3ntz0gaYmk3cWie2z/3vZm2xfV2GaN7RHbI+Pj49OtAqACDYff9mcl/VrS9yLihKSfSPqCpMWafGXww+m2i4iNETEUEUP9/f1taBlAOzQUftuf0WTwfxYRv5GkiDgSEScjYkLSTyUt7VybANqtbvg9eXnWTZL2RsSPpiyfP2W1lZLebH97ADqlkU/7b5T0DUlv2B4tlq2VNGx7saSQNCbpOx3pEC254YYbSus7d+4srTPUd/Zq5NP+30ma7uLsjOkDMxjf8AOSIvxAUoQfSIrwA0kRfiApwg8kxaW7Z4C77767pTowHc78QFKEH0iK8ANJEX4gKcIPJEX4gaQIP5CUI6J7B7PHJf3PlEVzJR3rWgNnpld769W+JHprVjt7uzwiGrpeXlfD/6mD2yMRMVRZAyV6tbde7Uuit2ZV1Rsv+4GkCD+QVNXh31jx8cv0am+92pdEb82qpLdK3/MDqE7VZ34AFakk/LZvtf2W7bdtP1BFD7XYHrP9hu1R2yMV97LZ9lHbb05Z1md7p+19xe2006RV1Ns62/9bPHejtv+5ot4W2v4v23tt77H9L8XySp+7kr4qed66/rLf9ixJ/y3pFkkHJb0qaTgi/tDVRmqwPSZpKCIqHxO2/Y+S/iLpiYi4tlj2r5KOR8T64g/nRRFxf4/0tk7SX6qeubmYUGb+1JmlJd0u6Zuq8Lkr6esOVfC8VXHmXyrp7YjYHxF/lfQLSSsq6KPnRcRLko6ftniFpK3F/a2a/M/TdTV66wkRcTgiXi/ufyDp1MzSlT53JX1VoorwL5B0YMrjg+qtKb9D0m9tv2Z7TdXNTOPSYtr0U9OnX1JxP6erO3NzN502s3TPPHfNzHjdblWEf7rZf3ppyOHGiPiypK9K+m7x8haNaWjm5m6ZZmbpntDsjNftVkX4D0paOOXx5yUdqqCPaUXEoeL2qKRt6r3Zh4+cmiS1uD1acT9/00szN083s7R64LnrpRmvqwj/q5KutL3I9mxJX5e0o4I+PsX2+cUHMbJ9vqTl6r3Zh3dIWl3cXy1pe4W9/J1embm51szSqvi567UZryv5kk8xlPGYpFmSNkfEI11vYhq2r9Dk2V6avLLxz6vszfbTkm7W5K++jkj6gaRnJP1K0mWS/iRpVUR0/YO3Gr3drMmXrn+bufnUe+wu93aTpF2S3pA0USxeq8n315U9dyV9DauC541v+AFJ8Q0/ICnCDyRF+IGkCD+QFOEHkiL8QFKEH0iK8ANJ/R8EiLFW9B5y7gAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(test_mat, cmap='Greys')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below there's a convenience function to display any image in the dataset by providing the index (for the \"test\" dataset, this should be a number between 0 and 9999):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def display_nth_image(i):\n",
+    "    plt.imshow(np.array(test_images[i]), cmap='Greys')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP8AAAD8CAYAAAC4nHJkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAADftJREFUeJzt3X+MVPW5x/HPoxdi+BGCYeWudnURiZYYS81IMN5Ubxoa0RqoCab8UTFp3CZivNWG+OMf/MMb9drS25ArZrmQUiyWJqASowWjBttEqysxVYpejNlbuCC7BA02GFD3uX/sod3izndmZ86cM8vzfiVkZ85zzpxnJ3z2zMz3zPmauwtAPGeV3QCAchB+ICjCDwRF+IGgCD8QFOEHgiL8QFCEHwiK8ANB/VORO5sxY4Z3d3cXuUsglP7+fh05csTqWbep8JvZ9ZJ+IelsSf/t7o+k1u/u7lZfX18zuwSQUKlU6l634Zf9Zna2pP+StEjSXEnLzGxuo48HoFjNvOefL+kDd//Q3U9K+o2kxfm0BaDVmgn/BZL2j7h/IFv2D8ysx8z6zKxvcHCwid0ByFMz4R/tQ4WvfD/Y3XvdveLulY6OjiZ2ByBPzYT/gKSuEfe/Julgc+0AKEoz4X9T0hwzm2VmEyV9X9L2fNoC0GoND/W5+xdmdqekHRoe6tvg7nty6wxASzU1zu/uz0t6PqdeABSI03uBoAg/EBThB4Ii/EBQhB8IivADQRF+ICjCDwRF+IGgCD8QFOEHgiL8QFCEHwiK8ANBEX4gKMIPBEX4gaAIPxAU4QeCIvxAUIQfCKrQKbrRGvv27atamz17dnLbWlOo7dixI1nftm1bsn7zzTcn6ylXX311sj5nzpyGHxsc+YGwCD8QFOEHgiL8QFCEHwiK8ANBEX4gqKbG+c2sX9Knkr6U9IW7V/JoKpoTJ04k6z09Pcn61q1bq9YmT57c1L6PHTuWrNeyffv2hredNGlSsj5lypRk/ZlnnqlaW7BgQUM9nUnyOMnnX939SA6PA6BAvOwHgmo2/C5pp5m9ZWbp16YA2kqzL/uvcfeDZnaepBfN7D13f3XkCtkfhR5JuvDCC5vcHYC8NHXkd/eD2c8BSU9Lmj/KOr3uXnH3SkdHRzO7A5CjhsNvZpPNbOqp25K+I+ndvBoD0FrNvOyfKelpMzv1OJvd/Xe5dAWg5RoOv7t/KOkbOfYS1kMPPZSsb9q0qeHHPn78eLJ+5ZVXJutdXV3J+rRp08bc0ylDQ0PJ+pNPPpms1/rdFi1aVLW2Z8+e5Lbnn39+sn4mYKgPCIrwA0ERfiAowg8ERfiBoAg/EBSX7i7ARx99lKyvW7euqcfv7u6uWnvhhReS23Z2dibr55xzTrI+ceLEZD3F3ZP1Wl+7veuuu5L1Tz75pGpt1apVyW3XrFmTrNd6XsYDjvxAUIQfCIrwA0ERfiAowg8ERfiBoAg/EBTj/AX47LPPkvWBgYFkPbtmQlWrV6+uWrv00kuT25ap1u91xx13JOu1Ljt+7733Vq2tX78+ue2KFSuS9Xnz5iXr4wFHfiAowg8ERfiBoAg/EBThB4Ii/EBQhB8IinH+Anz++edNbX/PPfck60uWLGnq8ceru+++O1nv7e2tWnv//feT227evDlZZ5wfwLhF+IGgCD8QFOEHgiL8QFCEHwiK8ANB1RznN7MNkr4racDdL8+WnStpi6RuSf2SbnH3j1vX5vi2cuXKpra/9tprc+oklqVLl1at1ZoW/eWXX867nbZTz5H/l5KuP23ZfZJecvc5kl7K7gMYR2qG391flXT0tMWLJW3Mbm+UFPMUM2Aca/Q9/0x3PyRJ2c/z8msJQBFa/oGfmfWYWZ+Z9Q0ODrZ6dwDq1Gj4D5tZpyRlP6tegdLde9294u6Vjo6OBncHIG+Nhn+7pOXZ7eWSns2nHQBFqRl+M3tK0muSLjWzA2b2Q0mPSFpoZvskLczuAxhHao7zu/uyKqVv59zLuPXxx+lTHPbt25esT58+PVmfO3fumHuCdMMNN1St1Rrnj4Az/ICgCD8QFOEHgiL8QFCEHwiK8ANBcenuHGzZsiVZf++995L122+/PVm/+OKLx9wTUAtHfiAowg8ERfiBoAg/EBThB4Ii/EBQhB8IinH+HKSmgpZqf2W32Ut7A43gyA8ERfiBoAg/EBThB4Ii/EBQhB8IivADQTHOX4CrrroqWb/kkksK6gT4O478QFCEHwiK8ANBEX4gKMIPBEX4gaAIPxBUzXF+M9sg6buSBtz98mzZg5JulzSYrfaAuz/fqibbwcmTJ6vWTpw4UWAnQD7qOfL/UtL1oyz/ubvPy/6d0cEHzkQ1w+/ur0o6WkAvAArUzHv+O83sT2a2wczS16kC0HYaDf9aSbMlzZN0SNLPqq1oZj1m1mdmfYODg9VWA1CwhsLv7ofd/Ut3H5K0TtL8xLq97l5x90pHR0ejfQLIWUPhN7POEXe/J+ndfNoBUJR6hvqeknSdpBlmdkDSKknXmdk8SS6pX9KPWtgjgBaoGX53XzbK4vUt6KWt7dq1q2pt7969yW27urrybgd12LJlS8PbTpgwIcdO2hNn+AFBEX4gKMIPBEX4gaAIPxAU4QeC4tLdGLf279+frG/atKnhx167dm3D244XHPmBoAg/EBThB4Ii/EBQhB8IivADQRF+ICjG+dG2ao3jP/bYY8n60aPVrzt74403Jre94oorkvUzAUd+ICjCDwRF+IGgCD8QFOEHgiL8QFCEHwiKcf46pS6/PW3atAI7OXMMDQ0l648++miy/vjjjyfrF110UdXamjVrktueddaZf1w8839DAKMi/EBQhB8IivADQRF+ICjCDwRF+IGgao7zm1mXpF9J+mdJQ5J63f0XZnaupC2SuiX1S7rF3T9uXavluuyyy6rWZs2aldz2yJEjyfrx48eT9UmTJiXrZTp48GCynhqLf+2115LbvvLKKw31dMqOHTuq1rq7u5t67DNBPUf+LyT9xN2/LmmBpBVmNlfSfZJecvc5kl7K7gMYJ2qG390Pufvu7PankvZKukDSYkkbs9U2SlrSqiYB5G9M7/nNrFvSNyX9UdJMdz8kDf+BkHRe3s0BaJ26w29mUyRtlfRjdz82hu16zKzPzPoGBwcb6RFAC9QVfjOboOHg/9rdt2WLD5tZZ1bvlDQw2rbu3uvuFXevdHR05NEzgBzUDL+ZmaT1kva6++oRpe2Slme3l0t6Nv/2ALRKPV/pvUbSDyS9Y2ZvZ8sekPSIpN+a2Q8l/UXS0ta0OP7t3r07Wa91GenU14nLtnPnzmR9YGDUF4R1mTlzZrJ+6623Juu1hmCjqxl+d/+DJKtS/na+7QAoCmf4AUERfiAowg8ERfiBoAg/EBThB4Li0t05eOKJJ5L1lStXJuu7du3Ks522kroEdq0zPh9++OFk/bbbbmukJWQ48gNBEX4gKMIPBEX4gaAIPxAU4QeCIvxAUIzz52D+/PnJ+nPPPZesL1y4MFl/4403xtxTUe6///5kfcGCBVVrN910U97tYAw48gNBEX4gKMIPBEX4gaAIPxAU4QeCIvxAUIzzF2Dq1KnJ+uuvv15QJ8DfceQHgiL8QFCEHwiK8ANBEX4gKMIPBEX4gaBqht/MuszsFTPba2Z7zOzfsuUPmtn/mdnb2b8bWt8ugLzUc5LPF5J+4u67zWyqpLfM7MWs9nN3/2nr2gPQKjXD7+6HJB3Kbn9qZnslXdDqxgC01pje85tZt6RvSvpjtuhOM/uTmW0ws+lVtukxsz4z6xscHGyqWQD5qTv8ZjZF0lZJP3b3Y5LWSpotaZ6GXxn8bLTt3L3X3SvuXqk1NxuA4tQVfjOboOHg/9rdt0mSux929y/dfUjSOknpq1gCaCv1fNpvktZL2uvuq0cs7xyx2vckvZt/ewBapZ5P+6+R9ANJ75jZ29myByQtM7N5klxSv6QftaRDAC1Rz6f9f5Bko5Sez78dAEXhDD8gKMIPBEX4gaAIPxAU4QeCIvxAUIQfCIrwA0ERfiAowg8ERfiBoAg/EBThB4Ii/EBQ5u7F7cxsUNL/jlg0Q9KRwhoYm3btrV37kuitUXn2dpG713W9vELD/5Wdm/W5e6W0BhLatbd27Uuit0aV1Rsv+4GgCD8QVNnh7y15/ynt2lu79iXRW6NK6a3U9/wAylP2kR9ASUoJv5ldb2bvm9kHZnZfGT1UY2b9ZvZONvNwX8m9bDCzATN7d8Syc83sRTPbl/0cdZq0knpri5mbEzNLl/rctduM14W/7DezsyX9j6SFkg5IelPSMnf/c6GNVGFm/ZIq7l76mLCZfUvSXyX9yt0vz5b9h6Sj7v5I9odzurvf2ya9PSjpr2XP3JxNKNM5cmZpSUsk3aYSn7tEX7eohOetjCP/fEkfuPuH7n5S0m8kLS6hj7bn7q9KOnra4sWSNma3N2r4P0/hqvTWFtz9kLvvzm5/KunUzNKlPneJvkpRRvgvkLR/xP0Daq8pv13STjN7y8x6ym5mFDOzadNPTZ9+Xsn9nK7mzM1FOm1m6bZ57hqZ8TpvZYR/tNl/2mnI4Rp3v1LSIkkrspe3qE9dMzcXZZSZpdtCozNe562M8B+Q1DXi/tckHSyhj1G5+8Hs54Ckp9V+sw8fPjVJavZzoOR+/qadZm4ebWZptcFz104zXpcR/jclzTGzWWY2UdL3JW0voY+vMLPJ2QcxMrPJkr6j9pt9eLuk5dnt5ZKeLbGXf9AuMzdXm1laJT937TbjdSkn+WRDGf8p6WxJG9z93wtvYhRmdrGGj/bS8CSmm8vszcyeknSdhr/1dVjSKknPSPqtpAsl/UXSUncv/IO3Kr1dp+GXrn+bufnUe+yCe/sXSb+X9I6koWzxAxp+f13ac5foa5lKeN44ww8IijP8gKAIPxAU4QeCIvxAUIQfCIrwA0ERfiAowg8E9f/Nl+OYHnXCawAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display_nth_image(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP8AAAD8CAYAAAC4nHJkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAADkJJREFUeJzt3X+MVPW5x/HPg1KRH4koKxJ+3C1Vi4bEbTOBm9CIl8ZGbpogGEz5o8HY3G0MJreG4BWNwYRcQ8wtteoNur2SQmz5kbReSDRX1DSRJqZhxIr0ItaYtcUlsEhNIRoq8PSPPTQr7nzP7syZObM+71dCduY8c+Y8TvzMmZnvOedr7i4A8YwpuwEA5SD8QFCEHwiK8ANBEX4gKMIPBEX4gaAIPxAU4QeCurSVG5syZYp3dna2cpNAKL29vTpx4oQN57ENhd/MbpP0U0mXSPofd9+QenxnZ6eq1WojmwSQUKlUhv3Yuj/2m9klkv5b0mJJN0paYWY31vt8AFqrke/88yS95+7vu/vfJG2XtKSYtgA0WyPhny7pz4PuH8mWfY6ZdZtZ1cyq/f39DWwOQJEaCf9QPyp84fxgd+9x94q7Vzo6OhrYHIAiNRL+I5JmDro/Q1JfY+0AaJVGwr9P0nVm9lUz+4qk70naXUxbAJqt7qE+dz9rZvdKekkDQ32b3f0PhXUGoKkaGud39xclvVhQLwBaiMN7gaAIPxAU4QeCIvxAUIQfCIrwA0G19Hx+tN6mTZuS9SeeeCJZf+mll5L1WbNmjbgntAf2/EBQhB8IivADQRF+ICjCDwRF+IGgGOr7Ejh8+HDN2oYNyQsqa+LEicn6W2+9lawz1Dd6secHgiL8QFCEHwiK8ANBEX4gKMIPBEX4gaAY5x8Fzpw5k6wvXLiwZu2+++5LrrtmzZq6esLox54fCIrwA0ERfiAowg8ERfiBoAg/EBThB4JqaJzfzHolnZJ0TtJZd68U0RQ+b8eOHcn65ZdfXrO2atWq5LpjxvD+H1URB/n8i7ufKOB5ALQQb/tAUI2G3yXtMbM3zKy7iIYAtEajH/sXuHufmV0t6WUze8fdXxv8gOxNoVviem9AO2loz+/ufdnf45KelzRviMf0uHvF3SsdHR2NbA5AgeoOv5lNMLNJF25L+o6kg0U1BqC5GvnYP1XS82Z24Xl+6e7/V0hXAJqu7vC7+/uSbiqwF9SQd8792rVra9byrsuPuBjqA4Ii/EBQhB8IivADQRF+ICjCDwTFpbvbQN6luT/99NNkvaurq8h2EAR7fiAowg8ERfiBoAg/EBThB4Ii/EBQhB8IinH+NrB///6G1p837wsXUAJysecHgiL8QFCEHwiK8ANBEX4gKMIPBEX4gaAY528DGzduTNZTU3BL0vjx44tsB0Gw5weCIvxAUIQfCIrwA0ERfiAowg8ERfiBoHLH+c1ss6TvSjru7nOzZVdK2iGpU1KvpDvd/S/Na3N0c/dkva+vL1m/4447imynbRw+fDhZf+655xp6/smTJ9esLVq0KLnuTTelZ583s7p6aifD2fP/XNJtFy17QNKr7n6dpFez+wBGkdzwu/trkk5etHiJpC3Z7S2Sbi+4LwBNVu93/qnuflSSsr9XF9cSgFZo+g9+ZtZtZlUzq/b39zd7cwCGqd7wHzOzaZKU/T1e64Hu3uPuFXevdHR01Lk5AEWrN/y7Ja3Mbq+UtKuYdgC0Sm74zWybpNclfd3MjpjZDyRtkHSrmf1R0q3ZfQCjSO44v7uvqFH6dsG9fGmdPn06WX/99deT9Q0b2ve99dy5c8n6Y489VrP20EMPJdedPXt2sn7VVVcl69dff33N2vr165Pr7t27N1mfO3dusj4acIQfEBThB4Ii/EBQhB8IivADQRF+ICgu3T0K5A1pNVPe6chr1qxJ1h9//PGatV270seGLV68OFm/9NL6//fdt29fsr5s2bJk/cCBA8n6uHHjRtxTq7HnB4Ii/EBQhB8IivADQRF+ICjCDwRF+IGgGOdvgUYvX5Z3amszrVu3LlnfuXNnsn7w4MGatRtuuCG5bjMvj93V1ZWsf/LJJ8n6Z599lqwzzg+gbRF+ICjCDwRF+IGgCD8QFOEHgiL8QFCM87fAyZMXz3PaPvIuK75169Zk/ZVXXknW58yZM+KeWmHs2LHJet5xAHnn8y9YsGDEPbUae34gKMIPBEX4gaAIPxAU4QeCIvxAUIQfCCp3nN/MNkv6rqTj7j43W/aIpH+TdOFE9Qfd/cVmNTna5Y0p5/n444+T9Wuuuabu5867dv6HH36YrF977bV1b3s0O3XqVNktNGw4e/6fS7ptiOU/cfeu7B/BB0aZ3PC7+2uS2vcQNQB1aeQ7/71mdsDMNpvZ5MI6AtAS9YZ/k6SvSeqSdFTSj2s90My6zaxqZtVGr2UHoDh1hd/dj7n7OXc/L+lnkuYlHtvj7hV3r3R0dNTbJ4CC1RV+M5s26O5SSbUv0QqgLQ1nqG+bpFskTTGzI5LWSbrFzLokuaReST9sYo8AmiA3/O6+YojFzzahly+tvHPaZ8yYkaw/88wzyXretfVT5s+fn6yfPXs2WX/nnXeS9blz5464p1Y4f/58sv7RRx8l61dccUWR7ZSCI/yAoAg/EBThB4Ii/EBQhB8IivADQXHp7ha47LLLkvW802J7enqS9YcffrhmbcyY9Pv7pEmTkvW89fOGAtvVjh07kvUPPvggWc+7tPdowJ4fCIrwA0ERfiAowg8ERfiBoAg/EBThB4JinL8NrF+/PllfuHBh3evnne47derUZP3+++9P1pcsWZKsr169umZt/PjxyXXz3Hzzzcl6X19fzdrdd9+dXPfNN99M1seNG5esjwbs+YGgCD8QFOEHgiL8QFCEHwiK8ANBEX4gKMb528CCBQuS9e7u7mT90UcfrVmbMGFCct177rknWc87BmHZsmXJeuoS2O6eXPfMmTPJet45+fv3769Ze/fdd5Przpw5M1n/MmDPDwRF+IGgCD8QFOEHgiL8QFCEHwiK8ANB5Y7zm9lMSVslXSPpvKQed/+pmV0paYekTkm9ku509780r9W4nnzyyWS9s7OzZm3t2rXJdZ9++ulk/a677krWZ8+enaynbNu2LVl/4YUXkvXly5cn60899VTN2vTp05PrRjCcPf9ZSavd/QZJ/yxplZndKOkBSa+6+3WSXs3uAxglcsPv7kfdfX92+5SkQ5KmS1oiaUv2sC2Sbm9WkwCKN6Lv/GbWKekbkn4naaq7H5UG3iAkXV10cwCaZ9jhN7OJkn4l6Ufu/tcRrNdtZlUzq/b399fTI4AmGFb4zWysBoL/C3f/dbb4mJlNy+rTJB0fal1373H3irtXOjo6iugZQAFyw29mJulZSYfcfeOg0m5JK7PbKyXtKr49AM1ieadVmtm3JO2V9LYGhvok6UENfO/fKWmWpD9JWu7uJ1PPValUvFqtNtozRqC3tzdZ3759e7K+Z8+eZH3fvn3J+tKlS2vW5s+fn1x30aJFyfqcOXOS9YH9ViyVSkXVanVY/+G54/zu/ltJtZ7s2yNpDED74Ag/ICjCDwRF+IGgCD8QFOEHgiL8QFC54/xFYpwfaK6RjPOz5weCIvxAUIQfCIrwA0ERfiAowg8ERfiBoAg/EBThB4Ii/EBQhB8IivADQRF+ICjCDwRF+IGgCD8QFOEHgiL8QFCEHwiK8ANBEX4gKMIPBEX4gaByw29mM83sN2Z2yMz+YGb/ni1/xMw+NLPfZ//+tfntAijKpcN4zFlJq919v5lNkvSGmb2c1X7i7v/VvPYANEtu+N39qKSj2e1TZnZI0vRmNwaguUb0nd/MOiV9Q9LvskX3mtkBM9tsZpNrrNNtZlUzq/b39zfULIDiDDv8ZjZR0q8k/cjd/yppk6SvSerSwCeDHw+1nrv3uHvF3SsdHR0FtAygCMMKv5mN1UDwf+Huv5Ykdz/m7ufc/bykn0ma17w2ARRtOL/2m6RnJR1y942Dlk8b9LClkg4W3x6AZhnOr/0LJH1f0ttm9vts2YOSVphZlySX1Cvph03pEEBTDOfX/t9KGmq+7xeLbwdAq3CEHxAU4QeCIvxAUIQfCIrwA0ERfiAowg8ERfiBoAg/EBThB4Ii/EBQhB8IivADQRF+IChz99ZtzKxf0geDFk2RdKJlDYxMu/bWrn1J9FavInv7J3cf1vXyWhr+L2zcrOruldIaSGjX3tq1L4ne6lVWb3zsB4Ii/EBQZYe/p+Ttp7Rrb+3al0Rv9Sqlt1K/8wMoT9l7fgAlKSX8ZnabmR02s/fM7IEyeqjFzHrN7O1s5uFqyb1sNrPjZnZw0LIrzexlM/tj9nfIadJK6q0tZm5OzCxd6mvXbjNet/xjv5ldIuldSbdKOiJpn6QV7v7/LW2kBjPrlVRx99LHhM3sZkmnJW1197nZsscknXT3Ddkb52R3/4826e0RSafLnrk5m1Bm2uCZpSXdLukulfjaJfq6UyW8bmXs+edJes/d33f3v0naLmlJCX20PXd/TdLJixYvkbQlu71FA//ztFyN3tqCux919/3Z7VOSLswsXeprl+irFGWEf7qkPw+6f0TtNeW3S9pjZm+YWXfZzQxhajZt+oXp068uuZ+L5c7c3EoXzSzdNq9dPTNeF62M8A81+087DTkscPdvSlosaVX28RbDM6yZm1tliJml20K9M14XrYzwH5E0c9D9GZL6SuhjSO7el/09Lul5td/sw8cuTJKa/T1ecj//0E4zNw81s7Ta4LVrpxmvywj/PknXmdlXzewrkr4naXcJfXyBmU3IfoiRmU2Q9B213+zDuyWtzG6vlLSrxF4+p11mbq41s7RKfu3abcbrUg7yyYYyHpd0iaTN7v6fLW9iCGY2WwN7e2lgEtNfltmbmW2TdIsGzvo6JmmdpP+VtFPSLEl/krTc3Vv+w1uN3m7RwEfXf8zcfOE7dot7+5akvZLelnQ+W/ygBr5fl/baJfpaoRJeN47wA4LiCD8gKMIPBEX4gaAIPxAU4QeCIvxAUIQfCIrwA0H9HdNVBvFD8z6xAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display_nth_image(100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that using a different colormap radically changes the way the image is displayed, so be mindful of what value you use for that argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7f03682ca6a0>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP8AAAD8CAYAAAC4nHJkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAADgpJREFUeJzt3X+MVfWZx/HPI4ImFBOViCiydBtduzGRbia6Caiz2UhwrYH+AVN/stnNTtFqFmNMif6ByabGbBbXTUwIQxw7TSilib9IsxEaop0aV8NATLXFtoSwMIIgodhpFMnA0z/mzO4U537PnXvPPedenvcrMffe89xz7+MNnznn3u8552vuLgDxXFB1AwCqQfiBoAg/EBThB4Ii/EBQhB8IivADQRF+ICjCDwR1YZlvZmYcTgi0mLtbPc9rastvZkvN7Ddmts/M1jbzWgDKZY0e229m0yT9VtLtkoYl7ZJ0t7v/OrEOW36gxcrY8t8kaZ+773f305J+LGlZE68HoETNhP9qSYcmPB7Olv0ZM+s1syEzG2rivQAUrJkf/CbbtfjSbr2790nqk9jtB9pJM1v+YUnXTHg8T9Lh5toBUJZmwr9L0rVm9lUzmyHp25K2FdMWgFZreLff3UfN7GFJ2yVNk9Tv7r8qrDMALdXwUF9Db8Z3fqDlSjnIB0DnIvxAUIQfCIrwA0ERfiAowg8EVer5/CjfunXrkvUHHnggWe/p6UnWh4Y4ZaNTseUHgiL8QFCEHwiK8ANBEX4gKMIPBMVQ33mgu7u7Zq23tze57meffZasd3V1JesM9XUutvxAUIQfCIrwA0ERfiAowg8ERfiBoAg/EBRX7+0As2bNStb3799fszYwMJBcd+3a9OTKef8+zpw5k6yjfFy9F0AS4QeCIvxAUIQfCIrwA0ERfiAowg8E1dT5/GZ2QNKIpDOSRt09ffI3GvLggw8m66dOnapZW79+fXLd0dHRhnpC5yviYh5/5+7HC3gdACVitx8Iqtnwu6QdZrbbzNLXiwLQVprd7V/k7ofN7ApJPzOzD919cOITsj8K/GEA2kxTW353P5zdHpP0iqSbJnlOn7t38WMg0F4aDr+ZzTSzWeP3JS2R9EFRjQForWZ2++dIesXMxl/nR+7+eiFdAWg5zufvAMePp0dSN27cWLP25JNPFt0O2hzn8wNIIvxAUIQfCIrwA0ERfiAowg8ExRTdbSDv0twXXXRRsv7hhx8W2Q6CYMsPBEX4gaAIPxAU4QeCIvxAUIQfCIrwA0Exzt8Gli5d2tT6r7/OZRQwdWz5gaAIPxAU4QeCIvxAUIQfCIrwA0ERfiAoxvnbwOrVq5P1L774Iln/5JNPimwHQbDlB4Ii/EBQhB8IivADQRF+ICjCDwRF+IGgcsf5zaxf0jclHXP3G7Jll0naKmmBpAOSVrr771vXZmczS8+YfPnllyfrO3fuLLKdttHd3Z2s9/T0NPX6J0+erFkbHBxMrpt3jYQyp7ZvlXq2/D+QdO7VJtZK2unu10ramT0G0EFyw+/ug5JOnLN4maSB7P6ApOUF9wWgxRr9zj/H3Y9IUnZ7RXEtAShDy4/tN7NeSb2tfh8AU9Polv+omc2VpOz2WK0nunufu3e5e1eD7wWgBRoN/zZJq7L7qyS9Vkw7AMqSG34z2yLpfyT9lZkNm9k/S3pG0u1m9jtJt2ePAXQQK3O80sw6f3C0AVdddVWyPjw8nKzfe++9yfqWLVum3FNRZsyYkaw/80zt7cKaNWuS6x48eDBZHxkZaXj9xYsXJ9ddsWJFsr5jx45kvUrunj6wJMMRfkBQhB8IivADQRF+ICjCDwRF+IGguHR3B6jy0twXXJDePmzatClZv//++2vWHnrooeS6L774YrKed0nzlOXL0+eibdy4MVlfuHBhsv7pp59OuaeyseUHgiL8QFCEHwiK8ANBEX4gKMIPBEX4gaAY5y/B/Pnzm1p/165dBXUydc8//3yyvmTJkobreZckb+Xp5tu3b0/WL7744mR95syZyTrj/ADaFuEHgiL8QFCEHwiK8ANBEX4gKMIPBMU4fwnmzJlTdQs1XXnllcn6XXfdlazfc889yfobb7wx5Z7K8Pnnnyfr+/btS9ZvueWWZH3r1q1T7qlsbPmBoAg/EBThB4Ii/EBQhB8IivADQRF+IKjccX4z65f0TUnH3P2GbNlTkv5F0vgF5Z9w9/9uVZOd7vTp002tP2/evGS9mXPH77vvvmQ97ziAt99+u+H37mSzZs2quoWm1bPl/4GkpZMs/093X5j9R/CBDpMbfncflHSihF4AlKiZ7/wPm9kvzazfzC4trCMApWg0/BskfU3SQklHJK2v9UQz6zWzITMbavC9ALRAQ+F396Pufsbdz0raJOmmxHP73L3L3bsabRJA8RoKv5nNnfDwW5I+KKYdAGWpZ6hvi6RuSbPNbFjSOkndZrZQkks6IOk7LewRQAvkht/d755k8Qst6OW89dZbbyXrH3/8cbK+evXqZP2RRx6Zck/j3nnnnWT9wgvT/0Ruu+22ZH3Hjh1T7qkMef9fl1xySbJ+8uTJItupBEf4AUERfiAowg8ERfiBoAg/EBThB4Li0t0lGBkZSdY/+uijZH3FihXJ+qOPPlqzNjo6mlz3xIn0OVtnz55N1qdNm5ast6u84dG8U5nzphfvBGz5gaAIPxAU4QeCIvxAUIQfCIrwA0ERfiAoc/fy3sysvDfrID09Pcn65s2bk/UNGzbUrDVzuq8k9fX1Jet33nlnst7f31+zdurUqYZ6Gpd3qvT8+fNr1jZt2pRc94477kjW23XqcUlyd6vneWz5gaAIPxAU4QeCIvxAUIQfCIrwA0ERfiAoxvk7wNatW5P15cuX16w999xzyXWfffbZZD1v+u+lSyebwPn/zZ49u2bNLD0cPWPGjGT9uuuuS9ZvvPHGmrXHHnssue7u3buT9XbGOD+AJMIPBEX4gaAIPxAU4QeCIvxAUIQfCCp3nN/MrpH0Q0lXSjorqc/d/8vMLpO0VdICSQckrXT33+e8FuP8DZg+fXqy/vTTT9esrVmzJrlu3pwBr776arJ+6NChZD0ldXyCJC1atChZz7t2/uOPP16z9t577yXX7WRFjvOPSnrM3b8u6W8lfdfM/lrSWkk73f1aSTuzxwA6RG743f2Iu+/J7o9I2ivpaknLJA1kTxuQlP4zDqCtTOk7v5ktkPQNSe9KmuPuR6SxPxCSrii6OQCtU/dcfWb2FUkvSVrj7n/IOy57wnq9knobaw9Aq9S15Tez6RoL/mZ3fzlbfNTM5mb1uZKOTbauu/e5e5e7dxXRMIBi5IbfxjbxL0ja6+4TTwHbJmlVdn+VpNeKbw9Aq9Qz1LdY0i8kva+xoT5JekJj3/t/Imm+pIOSVrh7cr5nhvrKd/PNNyfrK1euTNZvvfXWZP36669P1t98882atT179iTXHRwcTNbzLp+dN734+areob7c7/zu/pakWi/291NpCkD74Ag/ICjCDwRF+IGgCD8QFOEHgiL8QFBcuhs4z3DpbgBJhB8IivADQRF+ICjCDwRF+IGgCD8QFOEHgiL8QFCEHwiK8ANBEX4gKMIPBEX4gaAIPxAU4QeCIvxAUIQfCIrwA0ERfiAowg8ERfiBoAg/EFRu+M3sGjN7w8z2mtmvzOxfs+VPmdlHZvZe9t8/tL5dAEXJnbTDzOZKmuvue8xslqTdkpZLWinpj+7+H3W/GZN2AC1X76QdF9bxQkckHcnuj5jZXklXN9cegKpN6Tu/mS2Q9A1J72aLHjazX5pZv5ldWmOdXjMbMrOhpjoFUKi65+ozs69I+rmk77v7y2Y2R9JxSS7p3zT21eCfcl6D3X6gxerd7a8r/GY2XdJPJW1392cnqS+Q9FN3vyHndQg/0GKFTdRpZibpBUl7JwY/+yFw3LckfTDVJgFUp55f+xdL+oWk9yWdzRY/IeluSQs1ttt/QNJ3sh8HU6/Flh9osUJ3+4tC+IHWK2y3H8D5ifADQRF+ICjCDwRF+IGgCD8QFOEHgiL8QFCEHwiK8ANBEX4gKMIPBEX4gaAIPxBU7gU8C3Zc0v9OeDw7W9aO2rW3du1LordGFdnbX9T7xFLP5//Sm5sNuXtXZQ0ktGtv7dqXRG+Nqqo3dvuBoAg/EFTV4e+r+P1T2rW3du1LordGVdJbpd/5AVSn6i0/gIpUEn4zW2pmvzGzfWa2tooeajGzA2b2fjbzcKVTjGXToB0zsw8mLLvMzH5mZr/LbiedJq2i3tpi5ubEzNKVfnbtNuN16bv9ZjZN0m8l3S5pWNIuSXe7+69LbaQGMzsgqcvdKx8TNrNbJf1R0g/HZ0Mys3+XdMLdn8n+cF7q7t9rk96e0hRnbm5Rb7Vmlv5HVfjZFTnjdRGq2PLfJGmfu+9399OSfixpWQV9tD13H5R04pzFyyQNZPcHNPaPp3Q1emsL7n7E3fdk90ckjc8sXelnl+irElWE/2pJhyY8HlZ7TfntknaY2W4z6626mUnMGZ8ZKbu9ouJ+zpU7c3OZzplZum0+u0ZmvC5aFeGfbDaRdhpyWOTufyPpDknfzXZvUZ8Nkr6msWncjkhaX2Uz2czSL0la4+5/qLKXiSbpq5LPrYrwD0u6ZsLjeZIOV9DHpNz9cHZ7TNIrGvua0k6Ojk+Smt0eq7if/+PuR939jLuflbRJFX522czSL0na7O4vZ4sr/+wm66uqz62K8O+SdK2ZfdXMZkj6tqRtFfTxJWY2M/shRmY2U9IStd/sw9skrcrur5L0WoW9/Jl2mbm51szSqviza7cZrys5yCcbynhO0jRJ/e7+/dKbmISZ/aXGtvbS2BmPP6qyNzPbIqlbY2d9HZW0TtKrkn4iab6kg5JWuHvpP7zV6K1bU5y5uUW91ZpZ+l1V+NkVOeN1If1whB8QE0f4AUERfiAowg8ERfiBoAg/EBThB4Ii/EBQhB8I6k8P+z+a3okJGgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(np.array(test_images[100]), plt.get_cmap('gray'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A quick look at the *contents* of the arrays, as the samples are read reveals that the images are in the range of 0-255, so they can be encoded as `uint8`:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_mat = np.array(test_images[0])"
+    "arr = np.array(test_images[0])"
    ]
   },
   {
@@ -318,245 +511,233 @@
     }
    ],
    "source": [
-    "test_mat.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dtype('int32')"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "test_mat.dtype"
+    "arr.shape"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.image.AxesImage at 0x222ee124b38>"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAANMElEQVR4nO3dXahd9ZnH8d9vYqPBFs0xRw1p9MQieHRwknKIQaU4lAm+XMRcODRKyaBMeqHSYi98mYtGQQzDtDUXQyGdxKTasRTamAgyNoSKKWjwKGc0meAcjWea1JjsEDBWhGryzMVZmTnGs9fZ7rX2S/J8P3DYe69nvTxs8svae//X3n9HhACc/f6q1w0A6A7CDiRB2IEkCDuQBGEHkjinmwebN29eDA0NdfOQQCoTExM6evSop6tVCrvtmyWtlzRL0r9FxLqy9YeGhjQ6OlrlkABKjIyMNK21/TLe9ixJ/yrpFklXS1pl++p29wegs6q8Z18q6Z2I2B8Rf5H0K0kr6mkLQN2qhH2BpANTHh8sln2O7TW2R22PNhqNCocDUEWVsE/3IcAXrr2NiA0RMRIRI4ODgxUOB6CKKmE/KGnhlMdfl/R+tXYAdEqVsL8m6Urbi2zPlvQdSdvraQtA3doeeouIz2zfJ+lFTQ69bYqIvbV1BqBWlcbZI+IFSS/U1AuADuJyWSAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EASlaZstj0h6SNJJyR9FhEjdTQFoH6Vwl7424g4WsN+AHQQL+OBJKqGPST9zvbrttdMt4LtNbZHbY82Go2KhwPQrqphvyEivinpFkn32v7W6StExIaIGImIkcHBwYqHA9CuSmGPiPeL2yOStkpaWkdTAOrXdthtn2/7a6fuS1ouaU9djQGoV5VP4y+RtNX2qf38e0T8Ry1dAahd22GPiP2S/qbGXgB0EENvQBKEHUiCsANJEHYgCcIOJFHHF2FSePXVV5vW1q9fX7rtggULSutz5swpra9evbq0PjAw0FYNuXBmB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkGGdvUdlY9/j4eEeP/fjjj5fWL7jggqa1ZcuW1d3OGWNoaKhp7eGHHy7d9rLLLqu5m97jzA4kQdiBJAg7kARhB5Ig7EAShB1IgrADSTDO3qLnnnuuaW1sbKx022uuuaa0vnfv3tL67t27S+vbtm1rWnvxxRdLt120aFFp/b333iutV3HOOeX//ObPn19aP3DgQNvHLhuDl6QHH3yw7X33K87sQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AE4+wtGh4ebqvWimuvvba0vmrVqtL6unXrmtYmJiZKt51pnH3//v2l9Spmz55dWp9pnH2m3huNRtPaVVddVbrt2WjGM7vtTbaP2N4zZdmA7R22x4vbuZ1tE0BVrbyM3yzp5tOWPSRpZ0RcKWln8RhAH5sx7BHxsqRjpy1eIWlLcX+LpNtr7gtAzdr9gO6SiDgkScXtxc1WtL3G9qjt0bL3UAA6q+OfxkfEhogYiYiRwcHBTh8OQBPthv2w7fmSVNweqa8lAJ3Qbti3Szr128qrJTX/jiWAvjDjOLvtZyXdJGme7YOSfiRpnaRf275H0h8l3dHJJlHuvPPOa1qrOp5c9RqCKmb6Hv/Ro0dL69ddd13T2vLly9vq6Uw2Y9gjotkVHd+uuRcAHcTlskAShB1IgrADSRB2IAnCDiTBV1zRMx9//HFpfeXKlaX1kydPltaffPLJprU5c+aUbns24swOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kwzo6e2bx5c2n9gw8+KK1fdNFFpfXLL7/8y7Z0VuPMDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJMM6Ojnr33Xeb1h544IFK+37llVdK65deemml/Z9tOLMDSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKMs6Ojnn/++aa1Tz/9tHTbO+4onwn8iiuuaKunrGY8s9veZPuI7T1Tlq21/SfbY8XfrZ1tE0BVrbyM3yzp5mmW/zQiFhd/L9TbFoC6zRj2iHhZ0rEu9AKgg6p8QHef7TeLl/lzm61ke43tUdujjUajwuEAVNFu2H8m6RuSFks6JOnHzVaMiA0RMRIRI4ODg20eDkBVbYU9Ig5HxImIOCnp55KW1tsWgLq1FXbb86c8XClpT7N1AfSHGcfZbT8r6SZJ82wflPQjSTfZXiwpJE1I+l4He0Qfm2msfOvWrU1r5557bum2TzzxRGl91qxZpXV83oxhj4hV0yze2IFeAHQQl8sCSRB2IAnCDiRB2IEkCDuQBF9xRSUbN5YPzOzatatp7c477yzdlq+w1oszO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kwTg7So2NjZXW77///tL6hRde2LT22GOPtdUT2sOZHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSYJw9uU8++aS0vmrVdD8u/P9OnDhRWr/rrrua1vi+endxZgeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJBhnP8udPHmytH7bbbeV1t9+++3S+vDwcGn90UcfLa2je2Y8s9teaPv3tvfZ3mv7+8XyAds7bI8Xt3M73y6AdrXyMv4zST+MiGFJyyTda/tqSQ9J2hkRV0raWTwG0KdmDHtEHIqIN4r7H0naJ2mBpBWSthSrbZF0e6eaBFDdl/qAzvaQpCWSdku6JCIOSZP/IUi6uMk2a2yP2h5tNBrVugXQtpbDbvurkn4j6QcRcbzV7SJiQ0SMRMTI4OBgOz0CqEFLYbf9FU0G/ZcR8dti8WHb84v6fElHOtMigDrMOPRm25I2StoXET+ZUtouabWkdcXtto50iEqOHTtWWn/ppZcq7f/pp58urQ8MDFTaP+rTyjj7DZK+K+kt26d+RPwRTYb817bvkfRHSXd0pkUAdZgx7BHxB0luUv52ve0A6BQulwWSIOxAEoQdSIKwA0kQdiAJvuJ6Fvjwww+b1pYtW1Zp388880xpfcmSJZX2j+7hzA4kQdiBJAg7kARhB5Ig7EAShB1IgrADSTDOfhZ46qmnmtb2799fad833nhjaX3y5w5wJuDMDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJMM5+BhgfHy+tr127tjuN4IzGmR1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkmhlfvaFkn4h6VJJJyVtiIj1ttdK+kdJjWLVRyLihU41mtmuXbtK68ePH29738PDw6X1OXPmtL1v9JdWLqr5TNIPI+IN21+T9LrtHUXtpxHxL51rD0BdWpmf/ZCkQ8X9j2zvk7Sg040BqNeXes9ue0jSEkm7i0X32X7T9ibbc5tss8b2qO3RRqMx3SoAuqDlsNv+qqTfSPpBRByX9DNJ35C0WJNn/h9Pt11EbIiIkYgYGRwcrKFlAO1oKey2v6LJoP8yIn4rSRFxOCJORMRJST+XtLRzbQKoasawe/LnQzdK2hcRP5myfP6U1VZK2lN/ewDq0sqn8TdI+q6kt2yPFcsekbTK9mJJIWlC0vc60iEquf7660vrO3bsKK0z9Hb2aOXT+D9Imu7HwRlTB84gXEEHJEHYgSQIO5AEYQeSIOxAEoQdSIKfkj4D3H333ZXqgMSZHUiDsANJEHYgCcIOJEHYgSQIO5AEYQeScER072B2Q9L/TFk0T9LRrjXw5fRrb/3al0Rv7aqzt8sjYtrff+tq2L9wcHs0IkZ61kCJfu2tX/uS6K1d3eqNl/FAEoQdSKLXYd/Q4+OX6dfe+rUvid7a1ZXeevqeHUD39PrMDqBLCDuQRE/Cbvtm22/bfsf2Q73ooRnbE7bfsj1me7THvWyyfcT2ninLBmzvsD1e3E47x16Peltr+0/Fczdm+9Ye9bbQ9u9t77O91/b3i+U9fe5K+urK89b19+y2Z0n6b0l/J+mgpNckrYqI/+pqI03YnpA0EhE9vwDD9rck/VnSLyLir4tl/yzpWESsK/6jnBsRD/ZJb2sl/bnX03gXsxXNnzrNuKTbJf2DevjclfT19+rC89aLM/tSSe9ExP6I+IukX0la0YM++l5EvCzp2GmLV0jaUtzfosl/LF3XpLe+EBGHIuKN4v5Hkk5NM97T566kr67oRdgXSDow5fFB9dd87yHpd7Zft72m181M45KIOCRN/uORdHGP+zndjNN4d9Np04z3zXPXzvTnVfUi7NNNJdVP4383RMQ3Jd0i6d7i5Spa09I03t0yzTTjfaHd6c+r6kXYD0paOOXx1yW934M+phUR7xe3RyRtVf9NRX341Ay6xe2RHvfzf/ppGu/pphlXHzx3vZz+vBdhf03SlbYX2Z4t6TuStvegjy+wfX7xwYlsny9pufpvKurtklYX91dL2tbDXj6nX6bxbjbNuHr83PV8+vOI6PqfpFs1+Yn8u5L+qRc9NOnrCkn/Wfzt7XVvkp7V5Mu6TzX5iugeSRdJ2ilpvLgd6KPenpb0lqQ3NRms+T3q7UZNvjV8U9JY8Xdrr5+7kr668rxxuSyQBFfQAUkQdiAJwg4kQdiBJAg7kARhB5Ig7EAS/wseauFUg51ZyQAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plt.imshow(test_mat, cmap='Greys')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
    "outputs": [],
    "source": [
-    "def display_nth_image(i):\n",
-    "    plt.imshow(np.array(test_images[i]), cmap='Greys')"
+    "arr1 = arr.reshape(1,28*28)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 19,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAANyUlEQVR4nO3df4xU9bnH8c+jhRh+hOBlJavduIhEL7mxlKwE4031prERjIGa2JQ/KibGbSLGVhuitn/gHyZqvaW5IVfMciHlYrU0AZUYvWCQYJpodSVU4a7e9RpuoSC7BA02GFB5+scebra45zvDnDNzBp73K5nMzHnmzHl2woczc75n5mvuLgDnvwuqbgBAaxB2IAjCDgRB2IEgCDsQxDdaubFp06Z5d3d3KzcJhLJv3z4dOXLExqoVCruZ3Szp3yRdKOk/3P3x1OO7u7vV399fZJMAEnp6enJrDb+NN7MLJf27pAWSZktaYmazG30+AM1V5DP7PEkfuvtH7n5S0u8kLSqnLQBlKxL2yyTtH3X/QLbs75hZr5n1m1n/8PBwgc0BKKJI2Mc6CPC1c2/dvc/de9y9p6Ojo8DmABRRJOwHJHWNuv9NSQeLtQOgWYqE/W1Js8xshpmNl/RDSVvKaQtA2RoeenP3L83sXklbNTL0ts7d95bWGYBSFRpnd/eXJb1cUi8AmojTZYEgCDsQBGEHgiDsQBCEHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIQdCIKwA0EQdiAIwg4EQdiBIAg7EARhB4Ig7EAQhB0IoqVTNqM5BgcHc2szZ85MrltrSq6tW7cm65s3b07Wb7vttmQ95brrrkvWZ82a1fBzR8SeHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeCYJy9DZw4cSJZ7+3tTdY3bdqUW5s4cWKhbR87dixZr2XLli0NrzthwoRkfdKkScn6Cy+8kFubP39+Qz2dywqF3cz2SfpM0leSvnT3njKaAlC+Mvbs/+LuR0p4HgBNxGd2IIiiYXdJ28zsHTMb84OlmfWaWb+Z9dc6DxtA8xQN+/XuPlfSAknLzOw7Zz7A3fvcvcfdezo6OgpuDkCjCoXd3Q9m10OSnpc0r4ymAJSv4bCb2UQzm3z6tqTvSdpTVmMAylXkaPx0Sc+b2ennedbd/6uUroJ59NFHk/UNGzY0/NzHjx9P1ufOnZusd3V1JetTpkw5655OO3XqVLL+zDPPJOu1/rYFCxbk1vbu3Ztc99JLL03Wz0UNh93dP5L0rRJ7AdBEDL0BQRB2IAjCDgRB2IEgCDsQBF9xbYGPP/44WV+zZk2h5+/u7s6tvfLKK8l1Ozs7k/WLLrooWR8/fnyynuLuyXqtr6Hed999yfqnn36aW1uxYkVy3VWrViXrtV6XdsSeHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeCYJy9BT7//PNkfWhoKFnPvkaca+XKlbm1q666KrlulWr9Xffcc0+yXutnsB988MHc2tq1a5PrLlu2LFmfM2dOst6O2LMDQRB2IAjCDgRB2IEgCDsQBGEHgiDsQBCMs7fAF198UWj9Bx54IFlfvHhxoec/V91///3Jel9fX27tgw8+SK777LPPJuuMswNoW4QdCIKwA0EQdiAIwg4EQdiBIAg7EATj7C2wfPnyQuvfcMMNJXUSy+23355bqzVN9muvvVZ2O5WruWc3s3VmNmRme0Ytu9jMXjWzwex6anPbBFBUPW/jfyPp5jOWPSRpu7vPkrQ9uw+gjdUMu7u/LunoGYsXSVqf3V4vKeb5msA5pNEDdNPd/ZAkZdeX5D3QzHrNrN/M+oeHhxvcHICimn403t373L3H3Xs6OjqavTkAORoN+2Ez65Sk7Dr986gAKtdo2LdIWprdXirpxXLaAdAsNcfZzew5STdKmmZmByStkPS4pN+b2V2S/iwpf0AzgE8++SRZHxwcTNanTk2PXM6ePfuse4K0cOHC3FqtcfbzUc2wu/uSnNJ3S+4FQBNxuiwQBGEHgiDsQBCEHQiCsANB8BXXEmzcuDFZf//995P1u+++O1m/4oorzron4Ezs2YEgCDsQBGEHgiDsQBCEHQiCsANBEHYgCMbZS5CaGliq/RXWoj81DdSDPTsQBGEHgiDsQBCEHQiCsANBEHYgCMIOBME4ewtce+21yfqVV17Zok4QGXt2IAjCDgRB2IEgCDsQBGEHgiDsQBCEHQiCcfY6nTx5Mrd24sSJFnYCNKbmnt3M1pnZkJntGbXsETP7i5ntzi75E2EDaAv1vI3/jaSbx1j+a3efk11eLrctAGWrGXZ3f13S0Rb0AqCJihygu9fM3s3e5uf+yJqZ9ZpZv5n1Dw8PF9gcgCIaDftqSTMlzZF0SNKv8h7o7n3u3uPuPR0dHQ1uDkBRDYXd3Q+7+1fufkrSGknzym0LQNkaCruZdY66+31Je/IeC6A91BxnN7PnJN0oaZqZHZC0QtKNZjZHkkvaJ+nHTeyxLezcuTO3NjAwkFy3q6ur7HZQh40bNza87rhx40rspD3UDLu7Lxlj8dom9AKgiThdFgiCsANBEHYgCMIOBEHYgSD4iivOWfv370/WN2zY0PBzr169uuF12xV7diAIwg4EQdiBIAg7EARhB4Ig7EAQhB0IgnF2tK1a4+hPPvlksn70aP5PJ95yyy3Jda+55ppk/VzEnh0IgrADQRB2IAjCDgRB2IEgCDsQBGEHgmCcvU6pn4OeMmVKCzs5f5w6dSpZf+KJJ5L1p556Klm//PLLc2urVq1KrnvBBefffvD8+4sAjImwA0EQdiAIwg4EQdiBIAg7EARhB4JgnL1OV199dW5txowZyXWPHDmSrB8/fjxZnzBhQrJepYMHDybrqbHwN954I7nujh07GurptK1bt+bWuru7Cz33uajmnt3Musxsh5kNmNleM/tJtvxiM3vVzAaz66nNbxdAo+p5G/+lpJ+5+z9Kmi9pmZnNlvSQpO3uPkvS9uw+gDZVM+zufsjdd2W3P5M0IOkySYskrc8etl7S4mY1CaC4szpAZ2bdkr4t6Y+Sprv7IWnkPwRJl+Ss02tm/WbWPzw8XKxbAA2rO+xmNknSJkk/dfdj9a7n7n3u3uPuPR0dHY30CKAEdYXdzMZpJOi/dffN2eLDZtaZ1TslDTWnRQBlqDn0ZmYmaa2kAXdfOaq0RdJSSY9n1y82pcPzwK5du5L1Wj9rnPp6bdW2bduWrA8NNb4PmD59erJ+xx13JOu1hkSjqWec/XpJP5L0npntzpb9XCMh/72Z3SXpz5Jub06LAMpQM+zu/gdJllP+brntAGgWTpcFgiDsQBCEHQiCsANBEHYgCL7iWoKnn346WV++fHmyvnPnzjLbaSupn2SudUblY489lqzfeeedjbQUFnt2IAjCDgRB2IEgCDsQBGEHgiDsQBCEHQiCcfYSzJs3L1l/6aWXkvWbbropWX/rrbfOuqdWefjhh5P1+fPn59ZuvfXWsttBAnt2IAjCDgRB2IEgCDsQBGEHgiDsQBCEHQiCcfYWmDx5crL+5ptvtqgTRMaeHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeCqBl2M+sysx1mNmBme83sJ9nyR8zsL2a2O7ssbH67ABpVz0k1X0r6mbvvMrPJkt4xs1ez2q/d/V+b1x6AstQzP/shSYey25+Z2YCky5rdGIByndVndjPrlvRtSX/MFt1rZu+a2Tozm5qzTq+Z9ZtZ//DwcKFmATSu7rCb2SRJmyT91N2PSVotaaakORrZ8/9qrPXcvc/de9y9p9bcXgCap66wm9k4jQT9t+6+WZLc/bC7f+XupyStkZT+1UUAlarnaLxJWitpwN1XjlreOeph35e0p/z2AJSlnqPx10v6kaT3zGx3tuznkpaY2RxJLmmfpB83pUMApajnaPwfJNkYpZfLbwdAs3AGHRAEYQeCIOxAEIQdCIKwA0EQdiAIwg4EQdiBIAg7EARhB4Ig7EAQhB0IgrADQRB2IAhz99ZtzGxY0v+NWjRN0pGWNXB22rW3du1LordGldnb5e4+5u+/tTTsX9u4Wb+791TWQEK79taufUn01qhW9cbbeCAIwg4EUXXY+yrefkq79taufUn01qiW9FbpZ3YArVP1nh1AixB2IIhKwm5mN5vZB2b2oZk9VEUPecxsn5m9l01D3V9xL+vMbMjM9oxadrGZvWpmg9n1mHPsVdRbW0zjnZhmvNLXrurpz1v+md3MLpT0P5JuknRA0tuSlrj7f7e0kRxmtk9Sj7tXfgKGmX1H0l8l/ae7/1O27JeSjrr749l/lFPd/cE26e0RSX+tehrvbLaiztHTjEtaLOlOVfjaJfr6gVrwulWxZ58n6UN3/8jdT0r6naRFFfTR9tz9dUlHz1i8SNL67PZ6jfxjabmc3tqCux9y913Z7c8knZ5mvNLXLtFXS1QR9ssk7R91/4Daa753l7TNzN4xs96qmxnDdHc/JI3845F0ScX9nKnmNN6tdMY0423z2jUy/XlRVYR9rKmk2mn873p3nytpgaRl2dtV1KeuabxbZYxpxttCo9OfF1VF2A9I6hp1/5uSDlbQx5jc/WB2PSTpebXfVNSHT8+gm10PVdzP/2unabzHmmZcbfDaVTn9eRVhf1vSLDObYWbjJf1Q0pYK+vgaM5uYHTiRmU2U9D2131TUWyQtzW4vlfRihb38nXaZxjtvmnFV/NpVPv25u7f8ImmhRo7I/6+kX1TRQ05fV0j6U3bZW3Vvkp7TyNu6LzTyjuguSf8gabukwez64jbqbYOk9yS9q5FgdVbU2z9r5KPhu5J2Z5eFVb92ib5a8rpxuiwQBGfQAUEQdiAIwg4EQdiBIAg7EARhB4Ig7EAQfwM4jBOnsR+MiAAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "display_nth_image(10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAOHUlEQVR4nO3df4xU9bnH8c+DUpEfiSArEsC7pWrQkLhtJnCTvQEvzW3EfxCMN+WPRqPJNgaTaghWagwmJGbjvbVe9Qbd3pLitZcfSWs00VSUNNEmpmFcEfEias3awhJYJKYQDRV47h97vFlx53uWmTNzZnner2QzM+eZs+dhwmfPzHzPOV9zdwG48E0ouwEArUHYgSAIOxAEYQeCIOxAEBe3cmMzZ870zs7OVm4SCGVgYEDHjh2z0WoNhd3MbpL0H5IukvRf7t6ben5nZ6eq1WojmwSQUKlUatbqfhtvZhdJ+k9JyyVdL2m1mV1f7+8D0FyNfGZfJOkjd//Y3f8uaZukFcW0BaBojYR9jqS/jnh8MFv2NWbWY2ZVM6sODQ01sDkAjWgk7KN9CfCNY2/dvc/dK+5e6ejoaGBzABrRSNgPSpo34vFcSYONtQOgWRoJ+25J15jZt83sW5J+KOnFYtoCULS6h97c/bSZ3SPpFQ0PvW129/cK6wxAoRoaZ3f3lyW9XFAvAJqIw2WBIAg7EARhB4Ig7EAQhB0IgrADQbT0fHa03qZNm5L1J554Ill/5ZVXkvWrrrrqvHtCOdizA0EQdiAIwg4EQdiBIAg7EARhB4Jg6O0CcODAgZq13t7kBX81derUZP2dd95J1hl6Gz/YswNBEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIyzjwOnTp1K1pcuXVqzdt999yXXXbduXV09Yfxhzw4EQdiBIAg7EARhB4Ig7EAQhB0IgrADQTDOPg5s3749Wb/00ktr1tasWZNcd8IE/t5H0VDYzWxA0glJZySddvdKEU0BKF4Re/Z/dvdjBfweAE3EezggiEbD7pJ2mtlbZtYz2hPMrMfMqmZWHRoaanBzAOrVaNi73f17kpZLWmNmS859grv3uXvF3SsdHR0Nbg5AvRoKu7sPZrdHJT0vaVERTQEoXt1hN7MpZjbtq/uSfiBpX1GNAShWI9/Gz5L0vJl99Xv+x91/X0hX+Jq8c87Xr19fs5Z3XXjEUXfY3f1jSTcU2AuAJmLoDQiCsANBEHYgCMIOBEHYgSA4xbUN5F0q+osvvkjWu7q6imwHFyj27EAQhB0IgrADQRB2IAjCDgRB2IEgCDsQBOPsbaC/v7+h9Rct4pohyMeeHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeCYJy9DTz22GPJempKZkmaPHlyke3gAsWeHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeCYJy9Bdw9WR8cHEzWb7311iLbaRsHDhxI1p977rmGfv/06dNr1pYtW5Zc94Yb0hMUZ1OVjyu5e3Yz22xmR81s34hlM8zsVTP7MLut/aoCaAtjeRv/a0k3nbPsAUm73P0aSbuyxwDaWG7Y3f11ScfPWbxC0pbs/hZJtxTcF4CC1fsF3Sx3PyxJ2e0VtZ5oZj1mVjWz6tDQUJ2bA9Copn8b7+597l5x90pHR0ezNweghnrDfsTMZktSdnu0uJYANEO9YX9R0u3Z/dslvVBMOwCaJXec3cy2SrpR0kwzOyhpg6ReSTvM7C5Jf5F0WzObHO9OnjyZrL/55pvJem9vb5HtFOrMmTPJ+qOPPlqz9uCDDybXnT9/frJ++eWXJ+vXXnttzdrGjRuT677xxhvJ+sKFC5P1dpQbdndfXaP0/YJ7AdBEHC4LBEHYgSAIOxAEYQeCIOxAEJziOg7kDTE1U97puevWrUvWH3/88Zq1F15IH56xfPnyZP3ii+v/77t79+5kfdWqVcn63r17k/VJkyadd0/Nxp4dCIKwA0EQdiAIwg4EQdiBIAg7EARhB4JgnL0FGr0cV96pns20YcOGZH3Hjh3J+r59+2rWrrvuuuS6zbxcc1dXV7L++eefJ+tffvllss44O4DSEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIyzt8Dx4+dOldc+8i5z/eyzzybrr732WrK+YMGC8+6pFSZOnJis543D553P3t3dfd49NRt7diAIwg4EQdiBIAg7EARhB4Ig7EAQhB0IgnH2Fsgb083z2WefJetXXnll3b8779rthw4dStavvvrqurc9np04caLsFs5b7p7dzDab2VEz2zdi2cNmdsjM9mQ/Nze3TQCNGsvb+F9LummU5b9w967s5+Vi2wJQtNywu/vrktr3eE8AY9LIF3T3mNne7G3+9FpPMrMeM6uaWbXRa7EBqF+9Yd8k6TuSuiQdlvTzWk909z53r7h7paOjo87NAWhUXWF39yPufsbdz0r6paRFxbYFoGh1hd3MZo94uFJS7esFA2gLuePsZrZV0o2SZprZQUkbJN1oZl2SXNKApB83scdxL++c7rlz5ybrzzzzTLKed233lMWLFyfrp0+fTtbff//9ZH3hwoXn3VMrnD17Nln/9NNPk/XLLrusyHZaIjfs7r56lMW/akIvAJqIw2WBIAg7EARhB4Ig7EAQhB0IglNcW+CSSy5J1vNOE+3r60vWH3rooZq1CRPSf8+nTZuWrOetnzc01662b9+erH/yySfJet6lptsRe3YgCMIOBEHYgSAIOxAEYQeCIOxAEIQdCIJx9jawcePGZH3p0qV1r593+uusWbOS9fvvvz9ZX7FiRbK+du3amrXJkycn182zZMmSZH1wcLBm7c4770yu+/bbbyfrkyZNStbbEXt2IAjCDgRB2IEgCDsQBGEHgiDsQBCEHQiCcfY20N3dnaz39PQk64888kjN2pQpU5Lr3n333cl63jEAq1atStZTl2R29+S6p06dStbzzknv7++vWfvggw+S686bNy9ZH4/YswNBEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIyzjwNPPvlkst7Z2Vmztn79+uS6Tz/9dLJ+xx13JOvz589P1lO2bt2arL/00kvJ+m233ZasP/XUUzVrc+bMSa57Icrds5vZPDP7g5ntN7P3zOwn2fIZZvaqmX2Y3U5vfrsA6jWWt/GnJa119+sk/aOkNWZ2vaQHJO1y92sk7coeA2hTuWF398Pu3p/dPyFpv6Q5klZI2pI9bYukW5rVJIDGndcXdGbWKem7kv4kaZa7H5aG/yBIuqLGOj1mVjWz6tDQUGPdAqjbmMNuZlMl/VbSve7+t7Gu5+597l5x90pHR0c9PQIowJjCbmYTNRz037j777LFR8xsdlafLeloc1oEUATLO83QzEzDn8mPu/u9I5b/m6RP3b3XzB6QNMPdk9cdrlQqXq1WC2gbYzUwMJCsb9u2LVnfuXNnsr579+5kfeXKlTVrixcvTq67bNmyZH3BggXJ+vB/3VgqlYqq1eqo//CxjLN3S/qRpHfNbE+27GeSeiXtMLO7JP1FUnrQE0CpcsPu7n+UVOtP5PeLbQdAs3C4LBAEYQeCIOxAEIQdCIKwA0HkjrMXiXF2oLlS4+zs2YEgCDsQBGEHgiDsQBCEHQiCsANBEHYgCMIOBEHYgSAIOxAEYQeCIOxAEIQdCIKwA0EQdiAIwg4EQdiBIAg7EARhB4Ig7EAQhB0IgrADQRB2IIjcsJvZPDP7g5ntN7P3zOwn2fKHzeyQme3Jfm5ufrsA6jWW+dlPS1rr7v1mNk3SW2b2alb7hbv/e/PaA1CUsczPfljS4ez+CTPbL2lOsxsDUKzz+sxuZp2SvivpT9mie8xsr5ltNrPpNdbpMbOqmVWHhoYaahZA/cYcdjObKum3ku51979J2iTpO5K6NLzn//lo67l7n7tX3L3S0dFRQMsA6jGmsJvZRA0H/Tfu/jtJcvcj7n7G3c9K+qWkRc1rE0CjxvJtvEn6laT97v7YiOWzRzxtpaR9xbcHoChj+Ta+W9KPJL1rZnuyZT+TtNrMuiS5pAFJP25KhwAKMZZv4/8oabT5nl8uvh0AzcIRdEAQhB0IgrADQRB2IAjCDgRB2IEgCDsQBGEHgiDsQBCEHQiCsANBEHYgCMIOBEHYgSDM3Vu3MbMhSZ+MWDRT0rGWNXB+2rW3du1Lord6FdnbP7j7qNd/a2nYv7Fxs6q7V0prIKFde2vXviR6q1ereuNtPBAEYQeCKDvsfSVvP6Vde2vXviR6q1dLeiv1MzuA1il7zw6gRQg7EEQpYTezm8zsgJl9ZGYPlNFDLWY2YGbvZtNQV0vuZbOZHTWzfSOWzTCzV83sw+x21Dn2SuqtLabxTkwzXuprV/b05y3/zG5mF0n6QNK/SDooabek1e7+vy1tpAYzG5BUcffSD8AwsyWSTkp61t0XZsselXTc3XuzP5TT3f2nbdLbw5JOlj2NdzZb0eyR04xLukXSHSrxtUv09a9qwetWxp59kaSP3P1jd/+7pG2SVpTQR9tz99clHT9n8QpJW7L7WzT8n6XlavTWFtz9sLv3Z/dPSPpqmvFSX7tEXy1RRtjnSPrriMcH1V7zvbuknWb2lpn1lN3MKGa5+2Fp+D+PpCtK7udcudN4t9I504y3zWtXz/TnjSoj7KNNJdVO43/d7v49ScslrcnermJsxjSNd6uMMs14W6h3+vNGlRH2g5LmjXg8V9JgCX2Myt0Hs9ujkp5X+01FfeSrGXSz26Ml9/P/2mka79GmGVcbvHZlTn9eRth3S7rGzL5tZt+S9ENJL5bQxzeY2ZTsixOZ2RRJP1D7TUX9oqTbs/u3S3qhxF6+pl2m8a41zbhKfu1Kn/7c3Vv+I+lmDX8j/2dJD5bRQ42+5kt6J/t5r+zeJG3V8Nu6LzX8juguSZdL2iXpw+x2Rhv19t+S3pW0V8PBml1Sb/+k4Y+GeyXtyX5uLvu1S/TVkteNw2WBIDiCDgiCsANBEHYgCMIOBEHYgSAIOxAEYQeC+D9hzzjMXc/FGgAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "display_nth_image(100)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.image.AxesImage at 0x222ee291ac8>"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAOBUlEQVR4nO3dfahcdX7H8c/HmChkI6jBGI2p20WxpWC2BC3Eh5RlJSpi9o+Y9bl04W50lY2INmz/UCiV0FbrH4Lkho2bFpvNgg8ry2IiQZuKuOSBVOPqrmmwmuSaaEPcLBptkm//uOdur/HOb+6dpzM33/cLhpk53zkz3wz3k3NmfnPOzxEhACe/U+puAEBvEHYgCcIOJEHYgSQIO5DEqb18Mdt89Q90WUR4rOVtbdltL7L9G9u7bK9o57kAdJdbHWe3PUXSbyV9W9IeSVsk3RwRvy6sw5Yd6LJubNkvk7QrInZHxBeSfirpxjaeD0AXtRP28yV9MOr+nmrZl9gesL3V9tY2XgtAm9r5gm6sXYWv7KZHxKCkQYndeKBO7WzZ90i6YNT9OZL2tdcOgG5pJ+xbJF1k++u2p0n6rqQXOtMWgE5reTc+Io7avkfSBklTJK2JiLc61hmAjmp56K2lF+MzO9B1XflRDYDJg7ADSRB2IAnCDiRB2IEkCDuQRE+PZ0fvPfTQQ8X6HXfcUawvXbq0WN+6lUMeJgu27EAShB1IgrADSRB2IAnCDiRB2IEkGHo7CSxcuLBhbWBgoLjup59+WqzPnz+/WGfobfJgyw4kQdiBJAg7kARhB5Ig7EAShB1IgrADSXB22UlgxowZxfru3bsb1tauXVtcd8WK8uS7zf4+jh07Vqyj9zi7LJAcYQeSIOxAEoQdSIKwA0kQdiAJwg4kwfHsk8Bdd91VrB85cqRh7dFHHy2ue/To0ZZ6wuTTVthtvyfpsKRjko5GRPlMBwBq04kt+19GxMcdeB4AXcRndiCJdsMekjba3mZ7zJOd2R6wvdU2JysDatTubvyCiNhn+xxJL9l+JyI2j35ARAxKGpQ4EAaoU1tb9ojYV10fkPScpMs60RSAzms57Lan254xclvSNZJ2dqoxAJ3Vzm78LEnP2R55nn+LiBc70hW+5MEHHyzWV61a1bA2NDTU6XYwSbUc9ojYLenSDvYCoIsYegOSIOxAEoQdSIKwA0kQdiAJDnHtA81OFX3aaacV6++8804n28FJii07kARhB5Ig7EAShB1IgrADSRB2IAnCDiTBOHsfWLRoUVvrv/giRxajObbsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AE4+x9YNmyZcX6559/Xqx/9NFHnWwHJym27EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBOPsPVBNa93Q2WefXaxv2rSpk+30jYULFxbrS5cubev5Dx061LC2efPm4rrNzhEQES31VKemW3bba2wfsL1z1LKzbL9k+93q+szutgmgXePZjf+JpBNPpbJC0qaIuEjSpuo+gD7WNOwRsVnSwRMW3yhpbXV7raTFHe4LQIe1+pl9VkQMSVJEDNk+p9EDbQ9IGmjxdQB0SNe/oIuIQUmDkmR78n2rAZwkWh162297tiRV1wc61xKAbmg17C9IurO6faekn3emHQDd4mbjhbbXSVooaaak/ZIekvS8pJ9JmivpfUlLIuLEL/HGeq6Uu/HnnXdesb5nz55i/dZbby3W161bN+GeOmXatGnF+sqVKxvWli9fXlz3/fffL9YPHz7c8vpXXHFFcd0lS5YU6xs3bizW6xQRY/6wo+ln9oi4uUHpW211BKCn+LkskARhB5Ig7EAShB1IgrADSXCI6yRQ56miTzmlvD1YvXp1sX777bc3rN19993FdZ966qlivdkptksWLy4fzrFq1apifd68ecX6J598MuGeuo0tO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kwTh7D8ydO7et9bds2dKhTibuiSeeKNavueaaluvNTpHdzdM1b9iwoVg//fTTi/Xp06cX64yzA6gNYQeSIOxAEoQdSIKwA0kQdiAJwg4kwTh7D8yaNavuFho699xzi/UbbrihWL/llluK9ZdffnnCPfXCZ599Vqzv2rWrWL/yyiuL9fXr10+4p25jyw4kQdiBJAg7kARhB5Ig7EAShB1IgrADSTDO3gNffPFFW+vPmTOnWG/n2OnbbrutWG82Dv/aa6+1/NqT2YwZM+puYcKabtltr7F9wPbOUcsetr3X9o7qcl132wTQrvHsxv9E0qIxlv9zRMyrLr/sbFsAOq1p2CNis6SDPegFQBe18wXdPbbfqHbzz2z0INsDtrfa3trGawFoU6thf1LSNyTNkzQk6dFGD4yIwYiYHxHzW3wtAB3QUtgjYn9EHIuI45JWS7qss20B6LSWwm579qi735G0s9FjAfSHpuPsttdJWihppu09kh6StND2PEkh6T1J3+9ij5Peq6++Wqx/+OGHxfqyZcuK9XvvvXfCPY14/fXXi/VTTy3/iVx99dXF+saNGyfcUy80+3edccYZxfqhQ4c62U5PNA17RNw8xuIfd6EXAF3Ez2WBJAg7kARhB5Ig7EAShB1IgkNce+Dw4cPF+t69e4v1JUuWFOv33Xdfw9rRo0eL6x48WD7s4fjx48X6lClTivV+1Wy4stmhvc2mm+5HbNmBJAg7kARhB5Ig7EAShB1IgrADSRB2IAlHRO9ezO7di00iS5cuLdaffvrpYv3JJ59sWGvn8FdJGhwcLNavv/76Yn3NmjUNa0eOHGmppxHNDh2eO3duw9rq1auL61577bXFer9ORS1JEeGxlrNlB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkGGefBNavX1+sL168uGHt8ccfL6772GOPFevNpoNetGisOT//38yZMxvW7DGHg/9g2rRpxfrFF19crF966aUNa/fff39x3W3bthXr/YxxdiA5wg4kQdiBJAg7kARhB5Ig7EAShB1IgnH2SWDq1KnF+iOPPNKwtnz58uK6zc5Z//zzzxfrH3zwQbFeUvp9gCQtWLCgWG927vYHHnigYW3Hjh3FdSezlsfZbV9g+2Xbb9t+y/YPq+Vn2X7J9rvV9ZmdbhpA54xnN/6opPsj4k8k/YWkH9j+U0krJG2KiIskbaruA+hTTcMeEUMRsb26fVjS25LOl3SjpLXVw9ZKKu+TAajVhOZ6s32hpG9K+pWkWRExJA3/h2D7nAbrDEgaaK9NAO0ad9htf03SM5KWR8Tvmh3EMCIiBiUNVs/BF3RATcY19GZ7qoaD/nREPFst3m97dlWfLelAd1oE0AlNh948vAlfK+lgRCwftfwfJf1PRKy0vULSWRHxYJPnYsveY5dffnmxftNNNxXrV111VbF+ySWXFOuvvPJKw9r27duL627evLlYb3Y652bTTZ+sGg29jWc3foGk2yW9aXtkcPJHklZK+pnt70l6X1J5EnEAtWoa9oh4VVKjD+jf6mw7ALqFn8sCSRB2IAnCDiRB2IEkCDuQBIe4AicZTiUNJEfYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJNA277Qtsv2z7bdtv2f5htfxh23tt76gu13W/XQCtajpJhO3ZkmZHxHbbMyRtk7RY0k2Sfh8R/zTuF2OSCKDrGk0SMZ752YckDVW3D9t+W9L5nW0PQLdN6DO77QslfVPSr6pF99h+w/Ya22c2WGfA9lbbW9vqFEBbxj3Xm+2vSfp3SX8fEc/aniXpY0kh6e80vKv/102eg914oMsa7caPK+y2p0r6haQNEfHYGPULJf0iIv6syfMQdqDLWp7Y0bYl/VjS26ODXn1xN+I7kna22ySA7hnPt/FXSPoPSW9KOl4t/pGkmyXN0/Bu/HuSvl99mVd6LrbsQJe1tRvfKYQd6D7mZweSI+xAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiTR9ISTHfaxpP8edX9mtawf9Wtv/dqXRG+t6mRvf9So0NPj2b/y4vbWiJhfWwMF/dpbv/Yl0VuretUbu/FAEoQdSKLusA/W/Pol/dpbv/Yl0VuretJbrZ/ZAfRO3Vt2AD1C2IEkagm77UW2f2N7l+0VdfTQiO33bL9ZTUNd6/x01Rx6B2zvHLXsLNsv2X63uh5zjr2aeuuLabwL04zX+t7VPf15zz+z254i6beSvi1pj6Qtkm6OiF/3tJEGbL8naX5E1P4DDNtXSfq9pH8ZmVrL9j9IOhgRK6v/KM+MiL/pk94e1gSn8e5Sb42mGf8r1fjedXL681bUsWW/TNKuiNgdEV9I+qmkG2voo+9FxGZJB09YfKOktdXttRr+Y+m5Br31hYgYiojt1e3DkkamGa/1vSv01RN1hP18SR+Mur9H/TXfe0jaaHub7YG6mxnDrJFptqrrc2ru50RNp/HupROmGe+b966V6c/bVUfYx5qapp/G/xZExJ9LulbSD6rdVYzPk5K+oeE5AIckPVpnM9U0489IWh4Rv6uzl9HG6Ksn71sdYd8j6YJR9+dI2ldDH2OKiH3V9QFJz2n4Y0c/2T8yg251faDmfv4gIvZHxLGIOC5ptWp876ppxp+R9HREPFstrv29G6uvXr1vdYR9i6SLbH/d9jRJ35X0Qg19fIXt6dUXJ7I9XdI16r+pqF+QdGd1+05JP6+xly/pl2m8G00zrprfu9qnP4+Inl8kXafhb+T/S9Lf1tFDg77+WNJ/Vpe36u5N0joN79b9r4b3iL4n6WxJmyS9W12f1Ue9/auGp/Z+Q8PBml1Tb1do+KPhG5J2VJfr6n7vCn315H3j57JAEvyCDkiCsANJEHYgCcIOJEHYgSQIO5AEYQeS+D/Y7GpN55lJcQAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "plt.imshow(np.array(test_images[100]), plt.get_cmap('gray'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
    "outputs": [],
    "source": [
-    "plt.imsave('img_0.png', np.array(test_images[0]), format = 'png', cmap = plt.get_cmap('gray'))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We need black digits on white background, so need a different colormap:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.imsave('img_0.png', np.array(test_images[0]), format = 'png', cmap = 'Greys')"
+    "lst = arr.reshape(28*28).tolist()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0,129,1,3,133,5,9,140,14,17,18,19,21,22,151,159,31,163,36,35,166,38,40,170,44,52,182,185,58,59,60,187,62,57,61,66,67,198,72,75,203,205,77,207,209,83,84,219,221,222,224,225,121,227,126,229,233,106,236,238,240,241,114,115,242,248,249,250,251,253,254,255'"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "import matplotlib.image as mpimg"
+    "','.join(str(i) for i in set(lst))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Serializing samples as images\n",
+    "\n",
+    "Manipulating samples as image files provides a more general dataset-management experience that avoids the MNIST-specific vagaries (note that it does this at the expense of possibly higher memory/disk usage).  \n",
+    "\n",
+    "After some experimentation, the `PIL` (or `pillow` for Python 3+) library was found the most effective to do this.  Below, the `Image` type comes from this library (the later use of `IPython.display` is an artifact of these experimentation having been carried out within a Jupyter notebook."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
-    "img = mpimg.imread('img_0.png')"
+    "img = Image.fromarray(arr.astype('uint8'))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img.save(\"test.png\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imgfrom = Image.open(\"test.png\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arrfrom = np.array(imgfrom)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x222ee2f2b70>"
+       "(28, 28)"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
-    },
+    }
+   ],
+   "source": [
+    "arrfrom.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAANMElEQVR4nO3dXahd9ZnH8d9vYqPBFs0xRw1p9MQieHRwknKIQaU4lAm+XMRcODRKyaBMeqHSYi98mYtGQQzDtDUXQyGdxKTasRTamAgyNoSKKWjwKGc0meAcjWea1JjsEDBWhGryzMVZmTnGs9fZ7rX2S/J8P3DYe69nvTxs8svae//X3n9HhACc/f6q1w0A6A7CDiRB2IEkCDuQBGEHkjinmwebN29eDA0NdfOQQCoTExM6evSop6tVCrvtmyWtlzRL0r9FxLqy9YeGhjQ6OlrlkABKjIyMNK21/TLe9ixJ/yrpFklXS1pl++p29wegs6q8Z18q6Z2I2B8Rf5H0K0kr6mkLQN2qhH2BpANTHh8sln2O7TW2R22PNhqNCocDUEWVsE/3IcAXrr2NiA0RMRIRI4ODgxUOB6CKKmE/KGnhlMdfl/R+tXYAdEqVsL8m6Urbi2zPlvQdSdvraQtA3doeeouIz2zfJ+lFTQ69bYqIvbV1BqBWlcbZI+IFSS/U1AuADuJyWSAJwg4kQdiBJAg7kARhB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EASlaZstj0h6SNJJyR9FhEjdTQFoH6Vwl7424g4WsN+AHQQL+OBJKqGPST9zvbrttdMt4LtNbZHbY82Go2KhwPQrqphvyEivinpFkn32v7W6StExIaIGImIkcHBwYqHA9CuSmGPiPeL2yOStkpaWkdTAOrXdthtn2/7a6fuS1ouaU9djQGoV5VP4y+RtNX2qf38e0T8Ry1dAahd22GPiP2S/qbGXgB0EENvQBKEHUiCsANJEHYgCcIOJFHHF2FSePXVV5vW1q9fX7rtggULSutz5swpra9evbq0PjAw0FYNuXBmB5Ig7EAShB1IgrADSRB2IAnCDiRB2IEkGGdvUdlY9/j4eEeP/fjjj5fWL7jggqa1ZcuW1d3OGWNoaKhp7eGHHy7d9rLLLqu5m97jzA4kQdiBJAg7kARhB5Ig7EAShB1IgrADSTDO3qLnnnuuaW1sbKx022uuuaa0vnfv3tL67t27S+vbtm1rWnvxxRdLt120aFFp/b333iutV3HOOeX//ObPn19aP3DgQNvHLhuDl6QHH3yw7X33K87sQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AE4+wtGh4ebqvWimuvvba0vmrVqtL6unXrmtYmJiZKt51pnH3//v2l9Spmz55dWp9pnH2m3huNRtPaVVddVbrt2WjGM7vtTbaP2N4zZdmA7R22x4vbuZ1tE0BVrbyM3yzp5tOWPSRpZ0RcKWln8RhAH5sx7BHxsqRjpy1eIWlLcX+LpNtr7gtAzdr9gO6SiDgkScXtxc1WtL3G9qjt0bL3UAA6q+OfxkfEhogYiYiRwcHBTh8OQBPthv2w7fmSVNweqa8lAJ3Qbti3Szr128qrJTX/jiWAvjDjOLvtZyXdJGme7YOSfiRpnaRf275H0h8l3dHJJlHuvPPOa1qrOp5c9RqCKmb6Hv/Ro0dL69ddd13T2vLly9vq6Uw2Y9gjotkVHd+uuRcAHcTlskAShB1IgrADSRB2IAnCDiTBV1zRMx9//HFpfeXKlaX1kydPltaffPLJprU5c+aUbns24swOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kwzo6e2bx5c2n9gw8+KK1fdNFFpfXLL7/8y7Z0VuPMDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJMM6Ojnr33Xeb1h544IFK+37llVdK65deemml/Z9tOLMDSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKMs6Ojnn/++aa1Tz/9tHTbO+4onwn8iiuuaKunrGY8s9veZPuI7T1Tlq21/SfbY8XfrZ1tE0BVrbyM3yzp5mmW/zQiFhd/L9TbFoC6zRj2iHhZ0rEu9AKgg6p8QHef7TeLl/lzm61ke43tUdujjUajwuEAVNFu2H8m6RuSFks6JOnHzVaMiA0RMRIRI4ODg20eDkBVbYU9Ig5HxImIOCnp55KW1tsWgLq1FXbb86c8XClpT7N1AfSHGcfZbT8r6SZJ82wflPQjSTfZXiwpJE1I+l4He0Qfm2msfOvWrU1r5557bum2TzzxRGl91qxZpXV83oxhj4hV0yze2IFeAHQQl8sCSRB2IAnCDiRB2IEkCDuQBF9xRSUbN5YPzOzatatp7c477yzdlq+w1oszO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kwTg7So2NjZXW77///tL6hRde2LT22GOPtdUT2sOZHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSYJw9uU8++aS0vmrVdD8u/P9OnDhRWr/rrrua1vi+endxZgeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJBhnP8udPHmytH7bbbeV1t9+++3S+vDwcGn90UcfLa2je2Y8s9teaPv3tvfZ3mv7+8XyAds7bI8Xt3M73y6AdrXyMv4zST+MiGFJyyTda/tqSQ9J2hkRV0raWTwG0KdmDHtEHIqIN4r7H0naJ2mBpBWSthSrbZF0e6eaBFDdl/qAzvaQpCWSdku6JCIOSZP/IUi6uMk2a2yP2h5tNBrVugXQtpbDbvurkn4j6QcRcbzV7SJiQ0SMRMTI4OBgOz0CqEFLYbf9FU0G/ZcR8dti8WHb84v6fElHOtMigDrMOPRm25I2StoXET+ZUtouabWkdcXtto50iEqOHTtWWn/ppZcq7f/pp58urQ8MDFTaP+rTyjj7DZK+K+kt26d+RPwRTYb817bvkfRHSXd0pkUAdZgx7BHxB0luUv52ve0A6BQulwWSIOxAEoQdSIKwA0kQdiAJvuJ6Fvjwww+b1pYtW1Zp388880xpfcmSJZX2j+7hzA4kQdiBJAg7kARhB5Ig7EAShB1IgrADSTDOfhZ46qmnmtb2799fad833nhjaX3y5w5wJuDMDiRB2IEkCDuQBGEHkiDsQBKEHUiCsANJMM5+BhgfHy+tr127tjuN4IzGmR1IgrADSRB2IAnCDiRB2IEkCDuQBGEHkmhlfvaFkn4h6VJJJyVtiIj1ttdK+kdJjWLVRyLihU41mtmuXbtK68ePH29738PDw6X1OXPmtL1v9JdWLqr5TNIPI+IN21+T9LrtHUXtpxHxL51rD0BdWpmf/ZCkQ8X9j2zvk7Sg040BqNeXes9ue0jSEkm7i0X32X7T9ibbc5tss8b2qO3RRqMx3SoAuqDlsNv+qqTfSPpBRByX9DNJ35C0WJNn/h9Pt11EbIiIkYgYGRwcrKFlAO1oKey2v6LJoP8yIn4rSRFxOCJORMRJST+XtLRzbQKoasawe/LnQzdK2hcRP5myfP6U1VZK2lN/ewDq0sqn8TdI+q6kt2yPFcsekbTK9mJJIWlC0vc60iEquf7660vrO3bsKK0z9Hb2aOXT+D9Imu7HwRlTB84gXEEHJEHYgSQIO5AEYQeSIOxAEoQdSIKfkj4D3H333ZXqgMSZHUiDsANJEHYgCcIOJEHYgSQIO5AEYQeScER072B2Q9L/TFk0T9LRrjXw5fRrb/3al0Rv7aqzt8sjYtrff+tq2L9wcHs0IkZ61kCJfu2tX/uS6K1d3eqNl/FAEoQdSKLXYd/Q4+OX6dfe+rUvid7a1ZXeevqeHUD39PrMDqBLCDuQRE/Cbvtm22/bfsf2Q73ooRnbE7bfsj1me7THvWyyfcT2ninLBmzvsD1e3E47x16Peltr+0/Fczdm+9Ye9bbQ9u9t77O91/b3i+U9fe5K+urK89b19+y2Z0n6b0l/J+mgpNckrYqI/+pqI03YnpA0EhE9vwDD9rck/VnSLyLir4tl/yzpWESsK/6jnBsRD/ZJb2sl/bnX03gXsxXNnzrNuKTbJf2DevjclfT19+rC89aLM/tSSe9ExP6I+IukX0la0YM++l5EvCzp2GmLV0jaUtzfosl/LF3XpLe+EBGHIuKN4v5Hkk5NM97T566kr67oRdgXSDow5fFB9dd87yHpd7Zft72m181M45KIOCRN/uORdHGP+zndjNN4d9Np04z3zXPXzvTnVfUi7NNNJdVP4383RMQ3Jd0i6d7i5Spa09I03t0yzTTjfaHd6c+r6kXYD0paOOXx1yW934M+phUR7xe3RyRtVf9NRX341Ay6xe2RHvfzf/ppGu/pphlXHzx3vZz+vBdhf03SlbYX2Z4t6TuStvegjy+wfX7xwYlsny9pufpvKurtklYX91dL2tbDXj6nX6bxbjbNuHr83PV8+vOI6PqfpFs1+Yn8u5L+qRc9NOnrCkn/Wfzt7XVvkp7V5Mu6TzX5iugeSRdJ2ilpvLgd6KPenpb0lqQ3NRms+T3q7UZNvjV8U9JY8Xdrr5+7kr668rxxuSyQBFfQAUkQdiAJwg4kQdiBJAg7kARhB5Ig7EAS/wseauFUg51ZyQAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
+       "dtype('uint8')"
       ]
      },
-     "metadata": {
-      "needs_background": "light"
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "arrfrom.dtype"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arrcheck = np.array(test_images[0]).astype('uint8')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
      },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.all(arrcheck == arrfrom)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAAxUlEQVR4nGNgGDaAEUKFpD77sfTFHeyS9xQYGBg+X4UKPuk6w8DAwMDAAuGm6l/TMnSweCzLwPDntSTDozPIOhkYGBgYBA3PmDIw/Lh1XShnGi5nBP+9KIRLTuzl/2AokwlDMlv0/U1cGq1//rPDJcfQ+m83Ky45zrM/rHBqrPu3Daec9+8PlrjkhO/+W4ZLjvn0v9vKuCTV/v3zxSUn/+BfMSMuydZ//0xwydl+QpdEClsbHoa7X1AkWZA5F53f4TIWEwAAaRE8kJuHrgAAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<PIL.PngImagePlugin.PngImageFile image mode=L size=28x28 at 0x7F6C26389898>"
+      ]
+     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
    "source": [
-    "plt.imshow(img, cmap = plt.cm.Greys)"
+    "display(imgfrom)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img2 = Image.fromarray(np.array(test_images[19]).astype('uint8'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAAAAABXZoBIAAAA1klEQVR4nGNgGPxgRTSMxYQhx+SkjFvSUIQBU1JtkzyUdRlT0sLHhIGBgYFBheEppjsW/LNgYGBgYNj7jgVDjvfxCogph95g2qklfeofAwMDg4DmbkxJG4YDDAwMDAzhwofgkjDz2bPeSc6R4LJjYGTghEsyQmn+9wwM/64/YGBw5viZvgjNPRw335eKMTAwMDz69+kohmv5hBgYGBgYpD+f11NFt5PhE4Ty4N56CdO1UCDIsJ8BpyQDwy98kgy4Ja0Y1XFL8v5/j+Cgx8COr9vxWUQVAABxOStrssY9hgAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "(28, 28, 4)"
+       "<PIL.Image.Image image mode=L size=28x28 at 0x7F6C263A5B00>"
       ]
      },
-     "execution_count": 27,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "img.shape"
+    "display(img2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Inference\n",
+    "\n",
+    "With the details of the dataset out of the way, we can now verify that the inference engine is working properly.  We do this by pulling the MNIST onnx model and the (very small) \"confirmation\" samples packed with it."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -565,50 +746,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 54,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "RuntimeError",
-     "evalue": "[ONNXRuntimeError] : 3 : NO_SUCHFILE : Load model from /data/mnist/model.onnx failed:Load model /data/mnist/model.onnx failed. File doesn't exist",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-29-486cf694b12d>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0msess\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mort\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mInferenceSession\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'/data/mnist/model.onnx'\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;32mc:\\users\\chanchala\\appdata\\local\\programs\\python\\python36\\lib\\site-packages\\onnxruntime\\capi\\session.py\u001b[0m in \u001b[0;36m__init__\u001b[1;34m(self, path_or_bytes, sess_options)\u001b[0m\n\u001b[0;32m     27\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     28\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpath_or_bytes\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mstr\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 29\u001b[1;33m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_sess\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mload_model\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpath_or_bytes\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     30\u001b[0m         \u001b[1;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpath_or_bytes\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mbytes\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     31\u001b[0m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_sess\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mread_bytes\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mpath_or_bytes\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mRuntimeError\u001b[0m: [ONNXRuntimeError] : 3 : NO_SUCHFILE : Load model from /data/mnist/model.onnx failed:Load model /data/mnist/model.onnx failed. File doesn't exist"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sess = ort.InferenceSession('/data/mnist/model.onnx', None)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 55,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'sess' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-30-ce1333b03886>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0min_name\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0msess\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget_inputs\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;36m0\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mname\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;31mNameError\u001b[0m: name 'sess' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "in_name = sess.get_inputs()[0].name"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +773,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -628,7 +784,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -637,7 +793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -649,34 +805,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1, 1, 28, 28)"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "input_data.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7f036835d588>"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAP8AAAD8CAYAAAC4nHJkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAEiFJREFUeJzt3X+MleWVB/DvYQT5GcDMCBN+7JQGV42JdDOOa1w3ro3VNkTkj5KiIRgbqAkkW1N1Cf/Uf9bgZi3bmE0jXaEU0RbTsmIkaw1Zg03EMBoBK+xCyFhmGZgBBAYREDj7x1yaEec953Kf977vxfP9JGRm7pn3vs9c7nfuzJz3eR5RVRBRPMPKHgARlYPhJwqK4ScKiuEnCorhJwqK4ScKiuEnCorhJwqK4ScK6poiT9bc3KxtbW1FnpIolK6uLhw5ckSq+dyk8IvI/QB+DqAJwH+o6grr89va2tDZ2ZlyyqvSxYsXzfqwYfX7Aaze5/YuDxep6nlYkwsXLph162tLHZd37qampqT7r1V7e3vVn1vz/7yINAH4dwDfBXAzgPkicnOt90dExUr5tt8BYJ+q7lfVcwB+A2BOPsMionpLCf8UAAcGfdxdue1LRGSxiHSKSGdfX1/C6YgoTynhH+qXpq/8Aqiqq1S1XVXbW1paEk5HRHlKCX83gGmDPp4K4GDacIioKCnh3w5gpoh8Q0RGAPgBgE35DIuI6q3mVp+qnheRpQDexECrb7Wq/im3kX2NpLbTzp8/b9atdt4119T3Uo6UVqLXbktdZcoam/d/4o2trFZenpKeGaq6GcDmnMZCRAXi5b1EQTH8REEx/ERBMfxEQTH8REEx/ERBFTqfPyqvT+/14r26Nb203lN2vX639bV7Y/PqKb127/oE7+uu5zTsolz9XwER1YThJwqK4ScKiuEnCorhJwqK4ScKiq2+AnhtpVRltry8czfq1Nd6rip8teArP1FQDD9RUAw/UVAMP1FQDD9RUAw/UVAMP1FQ7PMXYMSIEWbd66V7U4It3nRgb2qqN7aUXXrr+XV7507t838drhPgKz9RUAw/UVAMP1FQDD9RUAw/UVAMP1FQDD9RUEl9fhHpAtAP4AKA86ransegovF6xsOHD6/buVP69EDaWgXefdd7e/EUKVuTN4o8Ht1/UNUjOdwPERWo8b89EVFdpIZfAfxBRN4XkcV5DIiIipH6Y/+dqnpQRK4H8JaI7FHVrYM/ofJNYTEATJ8+PfF0RJSXpFd+VT1YedsLYCOAjiE+Z5Wqtqtqe0tLS8rpiChHNYdfRMaIyLhL7wP4DoCP8hoYEdVXyo/9kwBsrLRrrgHwsqr+Vy6jIqK6qzn8qrofwK05jiWszz//3Kx7PeOzZ89m1vbs2WMe29/fb9bHjRtn1s+dO2fWrX74tddeax6bOmd+4sSJmbXW1lbz2DFjxpj1q6GP77n6vwIiqgnDTxQUw08UFMNPFBTDTxQUw08UVOPOmfwa8dphO3fuNOs7duww652dnZm19evXm8eePn3arE+YMMGsHz9+3KyPHj06s+a1y06dOmXWPTfddFNm7bHHHjOPnTt3rlmfPHmyWa/nNOy88JWfKCiGnygohp8oKIafKCiGnygohp8oKIafKKiG6vN7WzKnLOXs9dq9bbQt27ZtM+sbNmww614v/tixY2bdetxS+83edQBWH987vrm52TzWmqoM+M+H3bt3Z9aeeeYZ89h169aZ9VdffdWst7W1mXWL91xtamqq+b4H4ys/UVAMP1FQDD9RUAw/UVAMP1FQDD9RUAw/UVAN1ef3+rbWdtLelsmp/W5ree2PP/7YPHblypVmfezYsWY9ZQtvr5fu9fFPnDhh1r2e9JQpUzJrhw4dMo+9cOGCWfe2F7fm3HvnPnLE3ni6p6en5nMD9nUlKdecXAm+8hMFxfATBcXwEwXF8BMFxfATBcXwEwXF8BMF5fb5RWQ1gNkAelX1lspt1wH4LYA2AF0A5qnqp959qarZF/b6m1a/2+v5pm73vHHjxsyatwb8qFGjzLq1lTQAHDhwwKx3dHRk1ry1760+POBv0T1t2jSzvmbNmszaF198YR7rbeHtXQfQ1dWVWbv99tvNY739CLyxjRw50qyn8K5pqVY1r/y/AnD/ZbctA7BFVWcC2FL5mIiuIm74VXUrgMuXkpkDYG3l/bUAHsx5XERUZ7X+zj9JVXsAoPL2+vyGRERFqPsf/ERksYh0ikind700ERWn1vAfFpFWAKi87c36RFVdpartqtruTTIhouLUGv5NABZW3l8I4LV8hkNERXHDLyKvAHgXwF+LSLeI/BDACgD3isheAPdWPiaiq4jb51fV+Rmlb1/pyUTE7OV7/UurV++tBeDtCbBv3z6z/sQTT2TWvH6z18/2+vh33XWXWd+6dWtmzbv+wXvM81ojvuj7Buy1DO644w7z2M2bN5v1N99806zfcMMNZt1agyF17Ylq8Qo/oqAYfqKgGH6ioBh+oqAYfqKgGH6ioBpq6e4UXktr2DD7+1xra6tZP3nyZGbNa5dNmDDBrHvTblOmh3qPS71ZU7hTp1l7rcLx48dn1p588knz2O3bt5v15cuXm/WlS5eadWtKsPd88p7L1eIrP1FQDD9RUAw/UVAMP1FQDD9RUAw/UVAMP1FQhfb5U5futnjTar2e8JkzZ8y6NbbPPvvMPPapp54y694y0mPGjDHr1teeOm3We1xTtg9P7fN7U6Utt956q1mfN2+eWX/55ZfNem9v5uJWAOwl0fPq43v4yk8UFMNPFBTDTxQUw08UFMNPFBTDTxQUw08UVKF9fm/p7pRevdfP9pbuvu+++8z6p59m70D+3HPPmccuWbLErHvbPXu8xy2F14v3etLW3HRv3N5y7ClLXFtz/QFg6tSpZv3o0aNmfdGiRWb9jTfeyKzV8+sejK/8REEx/ERBMfxEQTH8REEx/ERBMfxEQTH8REG5fX4RWQ1gNoBeVb2lctvTABYB6Kt82nJVtfc0rkJKz9g71qvv2LHDrM+cOTOzNm3aNPNYr4/vrQfgzedPmbPvzYlP7Slbj7t37UUqa8+C06dPm8d61yB4j8u2bdvMuvWc8J6ree3FUM0r/68A3D/E7StVdVblX3LwiahYbvhVdSuAYwWMhYgKlPI7/1IR2Skiq0VkYm4jIqJC1Br+XwD4JoBZAHoAZF7cLiKLRaRTRDr7+vqyPo2IClZT+FX1sKpeUNWLAH4JoMP43FWq2q6q7S0tLbWOk4hyVlP4RWTwlrZzAXyUz3CIqCjVtPpeAXA3gGYR6QbwUwB3i8gsAAqgC8CP6jhGIqoDN/yqOn+Im1+sw1jc/mXKeuapa6E/9NBDmbUHHnjAPNbbb93r43usfnnq3HDv/yRl7X3v3Kl7MWzZsiWz9s4775jHvvDCC2bduz7Cm89v7V8xcuRI89jU/Q4u4RV+REEx/ERBMfxEQTH8REEx/ERBMfxEQRW6dDeQtp10yjLQ3n1PnGhPT1i7dm1m7dFHHzWPnT59ullPXXo7dRtui9WSAtKWHfdaVps325NFDxw4YNatrdG9NuPx48fN+tixY836448/bta9dp7FajNeyXRfvvITBcXwEwXF8BMFxfATBcXwEwXF8BMFxfATBVV4nz+lJ21Ny02dsmttwQ3Yfd8FCxaYx65bt86seyscjRo1yqynOHnypFl//fXXzfrbb79t1q1evveYHzx40Kzv2bPHrHtLolu8adbLli0z6zNmzKj53GfPnjXr1jb3VzLdl6/8REEx/ERBMfxEQTH8REEx/ERBMfxEQTH8REEV2udXVXfJY0vKdtH9/f1mffz48Wbd2tL53XffNY+95557zPrkyZPNutfn/+STTzJr3rzz5uZms75r1y6zfujQIbNuXdcxZcoU89ju7m6z7q0lYJ3bW0792WefNeuPPPKIWffuP2UNBy7dTURJGH6ioBh+oqAYfqKgGH6ioBh+oqAYfqKg3D6/iEwD8GsAkwFcBLBKVX8uItcB+C2ANgBdAOapqjlBW0TMXr235njKVtTjxo0z63v37jXrra2tmTWvZ3v06FGzvn//frPusR4373GxHtNqeNdeWNd1ePP1vV751KlTzXpHR0dm7aWXXjKP9aRuXX4l6+vXSzWv/OcB/ERVbwLwtwCWiMjNAJYB2KKqMwFsqXxMRFcJN/yq2qOqH1Te7wewG8AUAHMAXNrGZi2AB+s1SCLK3xX9zi8ibQC+BeA9AJNUtQcY+AYB4Pq8B0dE9VN1+EVkLIDfAfixqtoLv335uMUi0ikinX19fbWMkYjqoKrwi8hwDAR/var+vnLzYRFprdRbAfQOdayqrlLVdlVt9xaqJKLiuOGXgT9bvghgt6r+bFBpE4CFlfcXAngt/+ERUb1UM6X3TgALAOwSkQ8rty0HsALABhH5IYA/A/i+d0eqijNnzmTWvWW9U6b0eltNe0s1W8tzd3V1mcd6y1t7JkyYYNat6cbWMs8AMHr0aLPuTYX2jl+0aFFm7cSJE+ax3lTmFStWmHWrnZba4vRaqJ68puWmcL8CVf0jgKyRfjvf4RBRUXiFH1FQDD9RUAw/UVAMP1FQDD9RUAw/UVCFLt0tIhg5cmTNx1t9W2+KpHeNgNd3XbNmTWbNm5L73nvvmXVve3FvafDnn38+s+b1s+fPn2/Wb7vtNrM+adIksz579uzMmreMu7c0t/e1Wb341D6793zzpiNbUrebr/o8hZyFiBoOw08UFMNPFBTDTxQUw08UFMNPFBTDTxRU4Vt0W/PqvbnnVm/W66t6vVPvOgDr/mfMmGEeO336dLPuzQ2fM2eOWX/44Ycza97XfeONN5p1b069d/9WL9/r46f+n6b08lOuIQD8tSlSpGzvPRhf+YmCYviJgmL4iYJi+ImCYviJgmL4iYJi+ImCKnw+v9fLr1U9+6pA2hzr1DXevTUQvDn3ZUrZa6Goee1DSf0/q6e8nut85ScKiuEnCorhJwqK4ScKiuEnCorhJwqK4ScKyg2/iEwTkf8Wkd0i8icR+cfK7U+LyP+JyIeVf9+r/3CJKC/VXMlwHsBPVPUDERkH4H0ReatSW6mq/1q/4RFRvbjhV9UeAD2V9/tFZDeAKfUeGBHV1xX9zi8ibQC+BeDS/lNLRWSniKwWkYkZxywWkU4R6ezr60saLBHlp+rwi8hYAL8D8GNVPQngFwC+CWAWBn4yeG6o41R1laq2q2p7S0tLDkMmojxUFX4RGY6B4K9X1d8DgKoeVtULqnoRwC8BdNRvmESUt2r+2i8AXgSwW1V/Nuj21kGfNhfAR/kPj4jqpZq/9t8JYAGAXSLyYeW25QDmi8gsAAqgC8CP6jJCIqqLav7a/0cAQy2Avjn/4RBRUXiFH1FQDD9RUAw/UVAMP1FQDD9RUAw/UVAMP1FQDD9RUAw/UVAMP1FQDD9RUAw/UVAMP1FQDD9RUKKqxZ1MpA/AJ4NuagZwpLABXJlGHVujjgvg2GqV59j+SlWrWi+v0PB/5eQinaraXtoADI06tkYdF8Cx1aqssfHHfqKgGH6ioMoO/6qSz29p1LE16rgAjq1WpYyt1N/5iag8Zb/yE1FJSgm/iNwvIv8jIvtEZFkZY8giIl0isquy83BnyWNZLSK9IvLRoNuuE5G3RGRv5e2Q26SVNLaG2LnZ2Fm61Meu0Xa8LvzHfhFpAvC/AO4F0A1gO4D5qvpxoQPJICJdANpVtfSesIj8PYBTAH6tqrdUbvsXAMdUdUXlG+dEVf2nBhnb0wBOlb1zc2VDmdbBO0sDeBDAIyjxsTPGNQ8lPG5lvPJ3ANinqvtV9RyA3wCYU8I4Gp6qbgVw7LKb5wBYW3l/LQaePIXLGFtDUNUeVf2g8n4/gEs7S5f62BnjKkUZ4Z8C4MCgj7vRWFt+K4A/iMj7IrK47MEMYVJl2/RL26dfX/J4Lufu3Fyky3aWbpjHrpYdr/NWRviH2v2nkVoOd6rq3wD4LoAllR9vqTpV7dxclCF2lm4Ite54nbcywt8NYNqgj6cCOFjCOIakqgcrb3sBbETj7T58+NImqZW3vSWP5y8aaefmoXaWRgM8do2043UZ4d8OYKaIfENERgD4AYBNJYzjK0RkTOUPMRCRMQC+g8bbfXgTgIWV9xcCeK3EsXxJo+zcnLWzNEp+7Bptx+tSLvKptDL+DUATgNWq+s+FD2IIIjIDA6/2wMAmpi+XOTYReQXA3RiY9XUYwE8B/CeADQCmA/gzgO+rauF/eMsY290Y+NH1Lzs3X/odu+Cx/R2AdwDsAnCxcvNyDPx+XdpjZ4xrPkp43HiFH1FQvMKPKCiGnygohp8oKIafKCiGnygohp8oKIafKCiGnyio/we4Ea7Yqp/E6gAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "plt.imshow(input_data[0,0,:,:], cmap = plt.cm.Greys)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 57,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dtype('float32')"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "input_data.dtype"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -685,34 +886,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "int(np.argmax(np.array(r[0]).squeeze(), axis=0))"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "display_nth_image(7)"
+    "# Inference on a png's content\n",
+    "\n",
+    "Now, let's try the same for the array we read from the sample we dumped to png earlier:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
-    "arr = np.array(test_images[7],dtype='float32').reshape(1,1,28,28)"
+    "arr = np.array(img2).astype('float32').reshape(1,1,28,28)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -721,131 +933,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 61,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "int(np.argmax(np.array(r[0]).squeeze(), axis=0))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Reading from a png\n",
-    "\n",
-    "If read from a png file, the input matrix looks different, every element has four color channels (RGBA).  Recall `img` is the image written to a file earlier."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type(img)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "img.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "img.dtype"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "imgarr = np.dot(img[...,:3], [0.299, 0.587, 0.114]).astype('float32')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "imgarr.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "imgarr.dtype"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Not convinced that this is the right way to convert images to grayscale, as it looks like the colorspace is flipped:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.imshow(imgarr, cmap = 'Greys')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "However, it seems to work:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "r = sess.run([out_name], {in_name : imgarr.reshape(1,1,28,28)})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "int(np.argmax(np.array(r[0]).squeeze(), axis=0))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print (\"Test\")"
    ]
   },
   {
@@ -872,7 +975,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Using PIL instead of `matplotlib.image` to dump to and read from pngs.  This encoder seems to preserve the information in the MNIST samples.